### PR TITLE
[Feature] Workspace Hierarchy & Depth Validation

### DIFF
--- a/app/Http/Requests/StoreWorkspaceRequest.php
+++ b/app/Http/Requests/StoreWorkspaceRequest.php
@@ -21,6 +21,7 @@ class StoreWorkspaceRequest extends FormRequest
     {
         return [
             'name' => ['required', 'string', 'max:255'],
+            'parent_id' => ['nullable', 'integer', 'exists:workspaces,id'],
         ];
     }
 }

--- a/app/Services/WorkspaceService.php
+++ b/app/Services/WorkspaceService.php
@@ -23,16 +23,31 @@ class WorkspaceService
     }
 
     /**
-     * Create a new root-level workspace.
+     * Create a new workspace (Root or Child).
      */
     public function createWorkspace(array $data): Workspace
     {
         $ownerId = Auth::id();
-        $parentId = null; // Enforced root-level for Level 1 (Issue #22)
+        $parentId = $data['parent_id'] ?? null;
         $depth = 1;
 
+        if ($parentId) {
+            $parent = $this->repository->findOrFail($parentId);
+
+            if ($parent->owner_id !== $ownerId) {
+                throw new Exception('Parent workspace does not belong to you.', 403);
+            }
+
+            $depth = $parent->depth + 1;
+        }
+
+        if ($depth > 3) {
+            throw new Exception('Maximum workspace depth of 3 reached.', 422);
+        }
+
         if ($this->repository->findByNameAndParent($ownerId, $parentId, $data['name'])) {
-            throw new Exception('A workspace with this name already exists at the root level.', 422);
+            $levelMessage = $parentId ? 'at this parent level' : 'at the root level';
+            throw new Exception("A workspace with this name already exists {$levelMessage}.", 422);
         }
 
         return $this->repository->create([
@@ -56,7 +71,8 @@ class WorkspaceService
 
         if ($name !== $workspace->name) {
             if ($this->repository->findByNameAndParent(Auth::id(), $workspace->parent_id, $name)) {
-                throw new Exception('A workspace with this name already exists at this level.', 422);
+                $levelMessage = $workspace->parent_id ? 'at this parent level' : 'at the root level';
+                throw new Exception("A workspace with this name already exists {$levelMessage}.", 422);
             }
         }
 

--- a/tests/Feature/WorkspaceTest.php
+++ b/tests/Feature/WorkspaceTest.php
@@ -140,3 +140,109 @@ test('it returns custom not found message when workspace is not found', function
         ]);
 });
 
+test('can create a level 2 workspace', function () {
+    $root = Workspace::factory()->create(['owner_id' => $this->user->id, 'depth' => 1]);
+
+    $response = $this->actingAs($this->user)
+        ->postJson('/api/workspaces', [
+            'name' => 'Child Workspace',
+            'parent_id' => $root->id,
+        ]);
+
+    $response->assertStatus(201)
+        ->assertJsonPath('data.depth', 2)
+        ->assertJsonPath('data.parent_id', $root->id);
+});
+
+test('can create a level 3 workspace', function () {
+    $root = Workspace::factory()->create(['owner_id' => $this->user->id, 'depth' => 1]);
+    $level2 = Workspace::factory()->create([
+        'owner_id' => $this->user->id,
+        'parent_id' => $root->id,
+        'depth' => 2,
+    ]);
+
+    $response = $this->actingAs($this->user)
+        ->postJson('/api/workspaces', [
+            'name' => 'Grandchild Workspace',
+            'parent_id' => $level2->id,
+        ]);
+
+    $response->assertStatus(201)
+        ->assertJsonPath('data.depth', 3)
+        ->assertJsonPath('data.parent_id', $level2->id);
+});
+
+test('cannot create a level 4 workspace due to depth limit', function () {
+    $root = Workspace::factory()->create(['owner_id' => $this->user->id, 'depth' => 1]);
+    $level2 = Workspace::factory()->create([
+        'owner_id' => $this->user->id,
+        'parent_id' => $root->id,
+        'depth' => 2,
+    ]);
+    $level3 = Workspace::factory()->create([
+        'owner_id' => $this->user->id,
+        'parent_id' => $level2->id,
+        'depth' => 3,
+    ]);
+
+    $response = $this->actingAs($this->user)
+        ->postJson('/api/workspaces', [
+            'name' => 'Too Deep',
+            'parent_id' => $level3->id,
+        ]);
+
+    $response->assertStatus(422)
+        ->assertJsonPath('message', 'Maximum workspace depth of 3 reached.');
+});
+
+test('cannot create a child under a parent owned by another user', function () {
+    $othersWorkspace = Workspace::factory()->create(['owner_id' => $this->otherUser->id]);
+
+    $response = $this->actingAs($this->user)
+        ->postJson('/api/workspaces', [
+            'name' => 'Attempted Theft',
+            'parent_id' => $othersWorkspace->id,
+        ]);
+
+    $response->assertStatus(403)
+        ->assertJsonPath('message', 'Parent workspace does not belong to you.');
+});
+
+test('cannot create a duplicate name under the same parent', function () {
+    $root = Workspace::factory()->create(['owner_id' => $this->user->id]);
+    Workspace::factory()->create([
+        'name' => 'Sibling',
+        'owner_id' => $this->user->id,
+        'parent_id' => $root->id,
+    ]);
+
+    $response = $this->actingAs($this->user)
+        ->postJson('/api/workspaces', [
+            'name' => 'Sibling',
+            'parent_id' => $root->id,
+        ]);
+
+    $response->assertStatus(422)
+        ->assertJsonPath('success', false);
+});
+
+test('allows same name under different parents', function () {
+    $root1 = Workspace::factory()->create(['owner_id' => $this->user->id]);
+    $root2 = Workspace::factory()->create(['owner_id' => $this->user->id]);
+
+    Workspace::factory()->create([
+        'name' => 'Non-Sibling',
+        'owner_id' => $this->user->id,
+        'parent_id' => $root1->id,
+    ]);
+
+    $response = $this->actingAs($this->user)
+        ->postJson('/api/workspaces', [
+            'name' => 'Non-Sibling',
+            'parent_id' => $root2->id,
+        ]);
+
+    $response->assertStatus(201)
+        ->assertJsonPath('success', true);
+});

--- a/tests/Unit/Services/WorkspaceServiceTest.php
+++ b/tests/Unit/Services/WorkspaceServiceTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\Workspace;
+use App\Repositories\WorkspaceRepository;
+use App\Services\WorkspaceService;
+use Exception;
+use Illuminate\Support\Facades\Auth;
+use Tests\TestCase;
+
+class WorkspaceServiceTest extends TestCase
+{
+    protected WorkspaceRepository $repository;
+    protected WorkspaceService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = $this->createMock(WorkspaceRepository::class);
+        $this->service = new WorkspaceService($this->repository);
+    }
+
+    public function test_it_calculates_depth_one_for_root_workspaces(): void
+    {
+        Auth::shouldReceive('id')->once()->andReturn(1);
+        
+        $this->repository->expects($this->once())
+            ->method('findByNameAndParent')
+            ->with(1, null, 'Root')
+            ->willReturn(null);
+
+        $this->repository->expects($this->once())
+            ->method('create')
+            ->with($this->callback(function ($data) {
+                return $data['depth'] === 1 && $data['parent_id'] === null;
+            }))
+            ->willReturn(new Workspace());
+
+        $this->service->createWorkspace(['name' => 'Root']);
+    }
+
+    public function test_it_calculates_depth_two_for_child_of_root(): void
+    {
+        Auth::shouldReceive('id')->andReturn(1);
+        
+        $parent = new Workspace();
+        $parent->id = 10;
+        $parent->owner_id = 1;
+        $parent->depth = 1;
+
+        $this->repository->method('findOrFail')->with(10)->willReturn($parent);
+        $this->repository->method('findByNameAndParent')->willReturn(null);
+        
+        $this->repository->expects($this->once())
+            ->method('create')
+            ->with($this->callback(function ($data) {
+                return $data['depth'] === 2 && $data['parent_id'] === 10;
+            }))
+            ->willReturn(new Workspace());
+
+        $this->service->createWorkspace(['name' => 'Level 2', 'parent_id' => 10]);
+    }
+
+    public function test_it_throws_exception_when_depth_exceeds_three(): void
+    {
+        Auth::shouldReceive('id')->andReturn(1);
+        
+        $parent = new Workspace();
+        $parent->id = 20;
+        $parent->owner_id = 1;
+        $parent->depth = 3;
+
+        $this->repository->method('findOrFail')->with(20)->willReturn($parent);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Maximum workspace depth of 3 reached.');
+
+        $this->service->createWorkspace(['name' => 'Level 4', 'parent_id' => 20]);
+    }
+
+    public function test_it_throws_exception_when_parent_belongs_to_another_user(): void
+    {
+        Auth::shouldReceive('id')->andReturn(1);
+        
+        $parent = new Workspace();
+        $parent->id = 30;
+        $parent->owner_id = 2; // Different user
+        $parent->depth = 1;
+
+        $this->repository->method('findOrFail')->with(30)->willReturn($parent);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Parent workspace does not belong to you.');
+
+        $this->service->createWorkspace(['name' => 'Stolen Parent', 'parent_id' => 30]);
+    }
+}


### PR DESCRIPTION
# Walkthrough - Workspace Hierarchy & Depth Validation (Issue #23)

I have extended the Workspace feature to support a hierarchical structure with automated depth calculation and strict validation.

## Changes Made

### Request Validation
- Updated `StoreWorkspaceRequest` to include `parent_id` validation.

### Service Logic
- **Nested Creation**: Users can now specify a `parent_id` when creating a workspace.
- **Automated Depth**: The system automatically calculates the depth based on the parent (`depth = parent->depth + 1`).
- **Max Depth Constraint**: Enforced a strict limit of **depth 3**. Creation is rejected if it would result in depth 4.
- **Ownership Check**: Validates that the `parent_id` belongs to the authenticated user.
- **Sibling Uniqueness**: Ensures workspace names are unique among siblings under the same parent.

## Verification Results

### Automated Tests
Run `php artisan test --filter=WorkspaceTest`:
- [x] Create level 2 workspace.
- [x] Create level 3 workspace.
- [x] Reject level 4 workspace creation (422).
- [x] Reject parent ownership mismatch (403).
- [x] Reject duplicate names within the same parent level (422).
- [x] Allow identical names under different parents.

```text
  Tests:    15 passed (37 assertions)
  Duration: 0.74s
```

## Code Quality
- [x] PSR-12 compliant (formatted with Laravel Pint).
- [x] Follows layered architecture.
