### PR TITLE
[Feature] Workspace Move Logic & Anti-Circular Dependency

### DIFF
--- a/app/Http/Controllers/WorkspaceController.php
+++ b/app/Http/Controllers/WorkspaceController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Helpers\ApiResponse;
+use App\Http\Requests\MoveWorkspaceRequest;
 use App\Http\Requests\StoreWorkspaceRequest;
 use App\Http\Requests\UpdateWorkspaceRequest;
 use App\Services\WorkspaceService;
@@ -52,5 +53,15 @@ class WorkspaceController extends Controller
         $this->service->deleteWorkspace($id);
 
         return ApiResponse::success(null, 'Workspace deleted successfully');
+    }
+
+    /**
+     * Move the specified workspace to a new parent.
+     */
+    public function move(int $id, MoveWorkspaceRequest $request): JsonResponse
+    {
+        $workspace = $this->service->moveWorkspace($id, $request->parent_id);
+
+        return ApiResponse::success($workspace, 'Workspace moved successfully');
     }
 }

--- a/app/Http/Controllers/WorkspaceController.php
+++ b/app/Http/Controllers/WorkspaceController.php
@@ -8,6 +8,7 @@ use App\Http\Requests\StoreWorkspaceRequest;
 use App\Http\Requests\UpdateWorkspaceRequest;
 use App\Services\WorkspaceService;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Auth;
 
 class WorkspaceController extends Controller
 {
@@ -20,7 +21,7 @@ class WorkspaceController extends Controller
      */
     public function index(): JsonResponse
     {
-        $workspaces = $this->service->getWorkspaces();
+        $workspaces = $this->service->getWorkspaces(Auth::id());
 
         return ApiResponse::success($workspaces, 'Workspaces retrieved successfully');
     }
@@ -30,7 +31,7 @@ class WorkspaceController extends Controller
      */
     public function store(StoreWorkspaceRequest $request): JsonResponse
     {
-        $workspace = $this->service->createWorkspace($request->validated());
+        $workspace = $this->service->createWorkspace(Auth::id(), $request->validated());
 
         return ApiResponse::success($workspace, 'Workspace created successfully', 201);
     }
@@ -40,7 +41,7 @@ class WorkspaceController extends Controller
      */
     public function update(int $id, UpdateWorkspaceRequest $request): JsonResponse
     {
-        $workspace = $this->service->renameWorkspace($id, $request->name);
+        $workspace = $this->service->renameWorkspace(Auth::id(), $id, $request->name);
 
         return ApiResponse::success($workspace, 'Workspace renamed successfully');
     }
@@ -50,7 +51,7 @@ class WorkspaceController extends Controller
      */
     public function destroy(int $id): JsonResponse
     {
-        $this->service->deleteWorkspace($id);
+        $this->service->deleteWorkspace(Auth::id(), $id);
 
         return ApiResponse::success(null, 'Workspace deleted successfully');
     }
@@ -60,7 +61,7 @@ class WorkspaceController extends Controller
      */
     public function move(int $id, MoveWorkspaceRequest $request): JsonResponse
     {
-        $workspace = $this->service->moveWorkspace($id, $request->parent_id);
+        $workspace = $this->service->moveWorkspace(Auth::id(), $id, $request->parent_id);
 
         return ApiResponse::success($workspace, 'Workspace moved successfully');
     }

--- a/app/Http/Requests/MoveWorkspaceRequest.php
+++ b/app/Http/Requests/MoveWorkspaceRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class MoveWorkspaceRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'parent_id' => ['nullable', 'integer', 'exists:workspaces,id'],
+        ];
+    }
+}

--- a/app/Repositories/WorkspaceRepository.php
+++ b/app/Repositories/WorkspaceRepository.php
@@ -59,4 +59,52 @@ class WorkspaceRepository
             ->where('name', $name)
             ->first();
     }
+
+    /**
+     * Check if a workspace is a descendant of another.
+     */
+    public function isDescendant(int $parentId, int $childId): bool
+    {
+        $child = $this->findOrFail($childId);
+
+        if ($child->parent_id === $parentId) {
+            return true;
+        }
+
+        if ($child->parent_id === null) {
+            return false;
+        }
+
+        return $this->isDescendant($parentId, $child->parent_id);
+    }
+
+    /**
+     * Get the maximum height of the subtree starting from this workspace.
+     * Root of subtree is height 1.
+     */
+    public function getSubtreeHeight(Workspace $workspace): int
+    {
+        $maxChildHeight = 0;
+
+        foreach ($workspace->children as $child) {
+            $childHeight = $this->getSubtreeHeight($child);
+            if ($childHeight > $maxChildHeight) {
+                $maxChildHeight = $childHeight;
+            }
+        }
+
+        return 1 + $maxChildHeight;
+    }
+
+    /**
+     * Update the depth of a workspace and all its descendants recursively.
+     */
+    public function updateSubtreeDepths(Workspace $workspace, int $newDepth): void
+    {
+        $workspace->update(['depth' => $newDepth]);
+
+        foreach ($workspace->children as $child) {
+            $this->updateSubtreeDepths($child, $newDepth + 1);
+        }
+    }
 }

--- a/app/Repositories/WorkspaceRepository.php
+++ b/app/Repositories/WorkspaceRepository.php
@@ -63,10 +63,8 @@ class WorkspaceRepository
     /**
      * Check if a workspace is a descendant of another.
      */
-    public function isDescendant(int $parentId, int $childId): bool
+    public function isDescendant(int $parentId, Workspace $child): bool
     {
-        $child = $this->findOrFail($childId);
-
         if ($child->parent_id === $parentId) {
             return true;
         }
@@ -75,7 +73,9 @@ class WorkspaceRepository
             return false;
         }
 
-        return $this->isDescendant($parentId, $child->parent_id);
+        $parent = $this->findOrFail($child->parent_id);
+
+        return $this->isDescendant($parentId, $parent);
     }
 
     /**
@@ -84,10 +84,21 @@ class WorkspaceRepository
      */
     public function getSubtreeHeight(Workspace $workspace): int
     {
+        // Eager load descendants to avoid N+1 queries during recursion (max depth 3)
+        $workspace->load('children.children');
+
+        return $this->calculateSubtreeHeight($workspace);
+    }
+
+    /**
+     * Helper to recursively calculate height without redundant loads.
+     */
+    protected function calculateSubtreeHeight(Workspace $workspace): int
+    {
         $maxChildHeight = 0;
 
         foreach ($workspace->children as $child) {
-            $childHeight = $this->getSubtreeHeight($child);
+            $childHeight = $this->calculateSubtreeHeight($child);
             if ($childHeight > $maxChildHeight) {
                 $maxChildHeight = $childHeight;
             }
@@ -102,6 +113,11 @@ class WorkspaceRepository
     public function updateSubtreeDepths(Workspace $workspace, int $newDepth): void
     {
         $workspace->update(['depth' => $newDepth]);
+
+        // Ensure children are loaded for the subtree update
+        if (! $workspace->relationLoaded('children')) {
+            $workspace->load('children');
+        }
 
         foreach ($workspace->children as $child) {
             $this->updateSubtreeDepths($child, $newDepth + 1);

--- a/app/Services/WorkspaceService.php
+++ b/app/Services/WorkspaceService.php
@@ -92,4 +92,48 @@ class WorkspaceService
 
         $this->repository->delete($workspace);
     }
+
+    /**
+     * Move a workspace to a new parent.
+     */
+    public function moveWorkspace(int $id, ?int $parentId): Workspace
+    {
+        $workspace = $this->repository->findOrFail($id);
+        $ownerId = Auth::id();
+
+        if ($workspace->owner_id !== $ownerId) {
+            throw new Exception('Unauthorized to move this workspace.', 403);
+        }
+
+        $newDepth = 1;
+
+        if ($parentId) {
+            if ($parentId === $id) {
+                throw new Exception('Cannot move a workspace to itself.', 422);
+            }
+
+            $parent = $this->repository->findOrFail($parentId);
+
+            if ($parent->owner_id !== $ownerId) {
+                throw new Exception('Parent workspace does not belong to you.', 403);
+            }
+
+            if ($this->repository->isDescendant($id, $parentId)) {
+                throw new Exception('Circular dependency detected: Cannot move a workspace to its own descendant.', 422);
+            }
+
+            $newDepth = $parent->depth + 1;
+        }
+
+        $subtreeHeight = $this->repository->getSubtreeHeight($workspace);
+
+        if (($newDepth + $subtreeHeight - 1) > 3) {
+            throw new Exception('Moving this workspace would exceed the maximum depth of 3.', 422);
+        }
+
+        $workspace = $this->repository->update($workspace, ['parent_id' => $parentId]);
+        $this->repository->updateSubtreeDepths($workspace, $newDepth);
+
+        return $workspace;
+    }
 }

--- a/app/Services/WorkspaceService.php
+++ b/app/Services/WorkspaceService.php
@@ -6,7 +6,6 @@ use App\Models\Workspace;
 use App\Repositories\WorkspaceRepository;
 use Exception;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Support\Facades\Auth;
 
 class WorkspaceService
 {
@@ -17,24 +16,23 @@ class WorkspaceService
     /**
      * Get all workspaces for the authenticated user.
      */
-    public function getWorkspaces(): Collection
+    public function getWorkspaces(int $userId): Collection
     {
-        return $this->repository->getByOwner(Auth::id());
+        return $this->repository->getByOwner($userId);
     }
 
     /**
      * Create a new workspace (Root or Child).
      */
-    public function createWorkspace(array $data): Workspace
+    public function createWorkspace(int $userId, array $data): Workspace
     {
-        $ownerId = Auth::id();
         $parentId = $data['parent_id'] ?? null;
         $depth = 1;
 
         if ($parentId) {
             $parent = $this->repository->findOrFail($parentId);
 
-            if ($parent->owner_id !== $ownerId) {
+            if ($parent->owner_id !== $userId) {
                 throw new Exception('Parent workspace does not belong to you.', 403);
             }
 
@@ -45,14 +43,14 @@ class WorkspaceService
             throw new Exception('Maximum workspace depth of 3 reached.', 422);
         }
 
-        if ($this->repository->findByNameAndParent($ownerId, $parentId, $data['name'])) {
+        if ($this->repository->findByNameAndParent($userId, $parentId, $data['name'])) {
             $levelMessage = $parentId ? 'at this parent level' : 'at the root level';
             throw new Exception("A workspace with this name already exists {$levelMessage}.", 422);
         }
 
         return $this->repository->create([
             'name' => $data['name'],
-            'owner_id' => $ownerId,
+            'owner_id' => $userId,
             'parent_id' => $parentId,
             'depth' => $depth,
         ]);
@@ -61,16 +59,16 @@ class WorkspaceService
     /**
      * Rename an existing workspace.
      */
-    public function renameWorkspace(int $id, string $name): Workspace
+    public function renameWorkspace(int $userId, int $id, string $name): Workspace
     {
         $workspace = $this->repository->findOrFail($id);
 
-        if ($workspace->owner_id !== Auth::id()) {
+        if ($workspace->owner_id !== $userId) {
             throw new Exception('Unauthorized to update this workspace.', 403);
         }
 
         if ($name !== $workspace->name) {
-            if ($this->repository->findByNameAndParent(Auth::id(), $workspace->parent_id, $name)) {
+            if ($this->repository->findByNameAndParent($userId, $workspace->parent_id, $name)) {
                 $levelMessage = $workspace->parent_id ? 'at this parent level' : 'at the root level';
                 throw new Exception("A workspace with this name already exists {$levelMessage}.", 422);
             }
@@ -82,11 +80,11 @@ class WorkspaceService
     /**
      * Delete a workspace.
      */
-    public function deleteWorkspace(int $id): void
+    public function deleteWorkspace(int $userId, int $id): void
     {
         $workspace = $this->repository->findOrFail($id);
 
-        if ($workspace->owner_id !== Auth::id()) {
+        if ($workspace->owner_id !== $userId) {
             throw new Exception('Unauthorized to delete this workspace.', 403);
         }
 
@@ -96,12 +94,11 @@ class WorkspaceService
     /**
      * Move a workspace to a new parent.
      */
-    public function moveWorkspace(int $id, ?int $parentId): Workspace
+    public function moveWorkspace(int $userId, int $id, ?int $parentId): Workspace
     {
         $workspace = $this->repository->findOrFail($id);
-        $ownerId = Auth::id();
 
-        if ($workspace->owner_id !== $ownerId) {
+        if ($workspace->owner_id !== $userId) {
             throw new Exception('Unauthorized to move this workspace.', 403);
         }
 
@@ -114,15 +111,26 @@ class WorkspaceService
 
             $parent = $this->repository->findOrFail($parentId);
 
-            if ($parent->owner_id !== $ownerId) {
+            if ($parent->owner_id !== $userId) {
                 throw new Exception('Parent workspace does not belong to you.', 403);
             }
 
-            if ($this->repository->isDescendant($id, $parentId)) {
+            // Check if sibling name conflict exists at the destination parent level
+            if ($this->repository->findByNameAndParent($userId, $parentId, $workspace->name)) {
+                $levelMessage = 'at this parent level';
+                throw new Exception("A workspace with this name already exists {$levelMessage}.", 422);
+            }
+
+            if ($this->repository->isDescendant($id, $parent)) {
                 throw new Exception('Circular dependency detected: Cannot move a workspace to its own descendant.', 422);
             }
 
             $newDepth = $parent->depth + 1;
+        } else {
+            // Check if sibling name conflict exists at the root level
+            if ($this->repository->findByNameAndParent($userId, null, $workspace->name)) {
+                throw new Exception('A workspace with this name already exists at the root level.', 422);
+            }
         }
 
         $subtreeHeight = $this->repository->getSubtreeHeight($workspace);

--- a/routes/api.php
+++ b/routes/api.php
@@ -17,4 +17,5 @@ Route::middleware('auth:sanctum')->group(function () {
     });
 
     Route::apiResource('/workspaces', WorkspaceController::class);
+    Route::patch('/workspaces/{id}/move', [WorkspaceController::class, 'move']);
 });

--- a/tests/Feature/WorkspaceTest.php
+++ b/tests/Feature/WorkspaceTest.php
@@ -246,3 +246,145 @@ test('allows same name under different parents', function () {
     $response->assertStatus(201)
         ->assertJsonPath('success', true);
 });
+
+test('can move a root workspace to be a child of another workspace', function () {
+    $workspace = Workspace::factory()->create(['owner_id' => $this->user->id, 'depth' => 1]);
+    $newParent = Workspace::factory()->create(['owner_id' => $this->user->id, 'depth' => 1]);
+
+    $response = $this->actingAs($this->user)
+        ->patchJson("/api/workspaces/{$workspace->id}/move", [
+            'parent_id' => $newParent->id,
+        ]);
+
+    $response->assertStatus(200)
+        ->assertJsonPath('data.parent_id', $newParent->id)
+        ->assertJsonPath('data.depth', 2);
+
+    $this->assertDatabaseHas('workspaces', [
+        'id' => $workspace->id,
+        'parent_id' => $newParent->id,
+        'depth' => 2,
+    ]);
+});
+
+test('can move a child workspace to be a root workspace', function () {
+    $parent = Workspace::factory()->create(['owner_id' => $this->user->id, 'depth' => 1]);
+    $workspace = Workspace::factory()->create([
+        'owner_id' => $this->user->id,
+        'parent_id' => $parent->id,
+        'depth' => 2,
+    ]);
+
+    $response = $this->actingAs($this->user)
+        ->patchJson("/api/workspaces/{$workspace->id}/move", [
+            'parent_id' => null,
+        ]);
+
+    $response->assertStatus(200)
+        ->assertJsonPath('data.parent_id', null)
+        ->assertJsonPath('data.depth', 1);
+});
+
+test('cannot move a workspace to itself', function () {
+    $workspace = Workspace::factory()->create(['owner_id' => $this->user->id]);
+
+    $response = $this->actingAs($this->user)
+        ->patchJson("/api/workspaces/{$workspace->id}/move", [
+            'parent_id' => $workspace->id,
+        ]);
+
+    $response->assertStatus(422)
+        ->assertJsonPath('message', 'Cannot move a workspace to itself.');
+});
+
+test('cannot move a workspace to its own descendant (circular)', function () {
+    $parent = Workspace::factory()->create(['owner_id' => $this->user->id, 'depth' => 1]);
+    $child = Workspace::factory()->create([
+        'owner_id' => $this->user->id,
+        'parent_id' => $parent->id,
+        'depth' => 2,
+    ]);
+
+    $response = $this->actingAs($this->user)
+        ->patchJson("/api/workspaces/{$parent->id}/move", [
+            'parent_id' => $child->id,
+        ]);
+
+    $response->assertStatus(422)
+        ->assertJsonPath('message', 'Circular dependency detected: Cannot move a workspace to its own descendant.');
+});
+
+test('recalculates depth for the whole subtree after move', function () {
+    $oldRoot = Workspace::factory()->create(['owner_id' => $this->user->id, 'depth' => 1]);
+    $workspace = Workspace::factory()->create([
+        'owner_id' => $this->user->id,
+        'parent_id' => $oldRoot->id,
+        'depth' => 2,
+    ]);
+    $descendant = Workspace::factory()->create([
+        'owner_id' => $this->user->id,
+        'parent_id' => $workspace->id,
+        'depth' => 3,
+    ]);
+
+    $newRoot = Workspace::factory()->create(['owner_id' => $this->user->id, 'depth' => 1]);
+
+    $response = $this->actingAs($this->user)
+        ->patchJson("/api/workspaces/{$workspace->id}/move", [
+            'parent_id' => $newRoot->id,
+        ]);
+
+    $response->assertStatus(200);
+
+    // Workspace should now be at depth 2 (child of newRoot at depth 1)
+    $this->assertDatabaseHas('workspaces', [
+        'id' => $workspace->id,
+        'depth' => 2,
+        'parent_id' => $newRoot->id,
+    ]);
+
+    // Descendant should now be at depth 3
+    $this->assertDatabaseHas('workspaces', [
+        'id' => $descendant->id,
+        'depth' => 3,
+        'parent_id' => $workspace->id,
+    ]);
+});
+
+test('blocks move if it would exceed depth limit', function () {
+    // Level 1 -> Level 2
+    $movedParent = Workspace::factory()->create(['owner_id' => $this->user->id, 'depth' => 1]);
+    $movedChild = Workspace::factory()->create([
+        'owner_id' => $this->user->id,
+        'parent_id' => $movedParent->id,
+        'depth' => 2,
+    ]);
+
+    // Destination is at Level 2
+    $destRoot = Workspace::factory()->create(['owner_id' => $this->user->id, 'depth' => 1]);
+    $destParent = Workspace::factory()->create([
+        'owner_id' => $this->user->id,
+        'parent_id' => $destRoot->id,
+        'depth' => 2,
+    ]);
+
+    // Moving $movedParent (height 2) under $destParent (depth 2) would result in depth 4 (2+2)
+    $response = $this->actingAs($this->user)
+        ->patchJson("/api/workspaces/{$movedParent->id}/move", [
+            'parent_id' => $destParent->id,
+        ]);
+
+    $response->assertStatus(422)
+        ->assertJsonPath('message', 'Moving this workspace would exceed the maximum depth of 3.');
+});
+
+test('cannot move workspace owned by another user', function () {
+    $workspace = Workspace::factory()->create(['owner_id' => $this->otherUser->id]);
+
+    $response = $this->actingAs($this->user)
+        ->patchJson("/api/workspaces/{$workspace->id}/move", [
+            'parent_id' => null,
+        ]);
+
+    $response->assertStatus(403);
+});

--- a/tests/Feature/WorkspaceTest.php
+++ b/tests/Feature/WorkspaceTest.php
@@ -388,3 +388,30 @@ test('cannot move workspace owned by another user', function () {
 
     $response->assertStatus(403);
 });
+
+test('cannot move workspace to a parent where a sibling with the same name exists', function () {
+    $parent = Workspace::factory()->create(['owner_id' => $this->user->id, 'depth' => 1]);
+
+    // Existing sibling under $parent
+    Workspace::factory()->create([
+        'name' => 'Conflict Name',
+        'owner_id' => $this->user->id,
+        'parent_id' => $parent->id,
+        'depth' => 2,
+    ]);
+
+    // Workspace to move (currently root)
+    $workspace = Workspace::factory()->create([
+        'name' => 'Conflict Name',
+        'owner_id' => $this->user->id,
+        'depth' => 1,
+    ]);
+
+    $response = $this->actingAs($this->user)
+        ->patchJson("/api/workspaces/{$workspace->id}/move", [
+            'parent_id' => $parent->id,
+        ]);
+
+    $response->assertStatus(422)
+        ->assertJsonPath('message', 'A workspace with this name already exists at this parent level.');
+});


### PR DESCRIPTION
# Walkthrough - Workspace Move Logic & Anti-Circular Dependency (Issue #24)

I have implemented the ability to move workspaces and their entire subtrees to new locations while maintaining hierarchical integrity.

## Changes Made

### Repository Improvements
- Added `isDescendant` to identify potential circular dependencies.
- Added `getSubtreeHeight` to validate depth constraints before moving.
- Added `updateSubtreeDepths` for recursive depth recalculation after relocation.

### Service Logic
- **Move Operation**: Users can now change a workspace's `parent_id`.
- **Anti-Circular Check**: Strictly prevents moving a workspace to be a child of itself or any of its descendants.
- **Subtree Recalculation**: Automatically updates the `depth` for the moved workspace and all its children/grandchildren.
- **Hierarchy Validation**: Rejects moves that would result in any node exceeding the **Depth 3** limit.

## Verification Results

### Automated Tests
Run `php artisan test --filter=WorkspaceTest`:
- [x] Move root to child.
- [x] Move child to root.
- [x] Reject circular move (parent to descendant).
- [x] Reject move to self.
- [x] Reject move exceeding depth limit (Subtree Height + Parent Depth > 3).
- [x] Verify recursive depth updates for descendants.

```text
  Tests:    22 passed (54 assertions)
  Duration: 1.39s
```

## Code Quality
- [x] PSR-12 compliant (formatted with Laravel Pint).
- [x] Layered Architecture (Controller -> Service -> Repository).\n\nCloses #24