### PR TITLE
[Feature] Workspace Delete & Cascade Behavior

### DIFF
--- a/app/Services/WorkspaceService.php
+++ b/app/Services/WorkspaceService.php
@@ -78,7 +78,7 @@ class WorkspaceService
     }
 
     /**
-     * Delete a workspace.
+     * Delete a workspace and all its descendants.
      */
     public function deleteWorkspace(int $userId, int $id): void
     {
@@ -86,6 +86,21 @@ class WorkspaceService
 
         if ($workspace->owner_id !== $userId) {
             throw new Exception('Unauthorized to delete this workspace.', 403);
+        }
+
+        $this->performRecursiveDelete($workspace);
+    }
+
+    /**
+     * Helper to recursively delete descendants.
+     */
+    protected function performRecursiveDelete(Workspace $workspace): void
+    {
+        // Load children to avoid N+1 queries
+        $workspace->load('children');
+
+        foreach ($workspace->children as $child) {
+            $this->performRecursiveDelete($child);
         }
 
         $this->repository->delete($workspace);

--- a/tests/Feature/WorkspaceTest.php
+++ b/tests/Feature/WorkspaceTest.php
@@ -415,3 +415,20 @@ test('cannot move workspace to a parent where a sibling with the same name exist
     $response->assertStatus(422)
         ->assertJsonPath('message', 'A workspace with this name already exists at this parent level.');
 });
+
+test('deleting a workspace also deletes all its descendants', function () {
+    // Root -> Child -> Grandchild
+    $root = Workspace::factory()->create(['owner_id' => $this->user->id, 'depth' => 1]);
+    $child = Workspace::factory()->create(['owner_id' => $this->user->id, 'parent_id' => $root->id, 'depth' => 2]);
+    $grandchild = Workspace::factory()->create(['owner_id' => $this->user->id, 'parent_id' => $child->id, 'depth' => 3]);
+
+    $response = $this->actingAs($this->user)
+        ->deleteJson("/api/workspaces/{$root->id}");
+
+    $response->assertStatus(200);
+
+    // Verify all are deleted
+    $this->assertDatabaseMissing('workspaces', ['id' => $root->id]);
+    $this->assertDatabaseMissing('workspaces', ['id' => $child->id]);
+    $this->assertDatabaseMissing('workspaces', ['id' => $grandchild->id]);
+});


### PR DESCRIPTION
Implement recursive workspace deletion to prevent orphaned database records. This change ensure that deleting a parent workspace automatically removes all its descendants. Closes #25