### PR TITLE
[Bug] Implement show method for workspaces

### DIFF
--- a/app/Http/Controllers/WorkspaceController.php
+++ b/app/Http/Controllers/WorkspaceController.php
@@ -47,6 +47,16 @@ class WorkspaceController extends Controller
     }
 
     /**
+     * Display the specified workspace.
+     */
+    public function show(int $id): JsonResponse
+    {
+        $workspace = $this->service->findWorkspace(Auth::id(), $id);
+
+        return ApiResponse::success($workspace, 'Workspace retrieved successfully');
+    }
+
+    /**
      * Remove the specified workspace from storage.
      */
     public function destroy(int $id): JsonResponse

--- a/app/Services/WorkspaceService.php
+++ b/app/Services/WorkspaceService.php
@@ -22,6 +22,20 @@ class WorkspaceService
     }
 
     /**
+     * Find a specific workspace with ownership validation.
+     */
+    public function findWorkspace(int $userId, int $id): Workspace
+    {
+        $workspace = $this->repository->findOrFail($id);
+
+        if ($workspace->owner_id !== $userId) {
+            throw new Exception('Unauthorized to access this workspace.', 403);
+        }
+
+        return $workspace;
+    }
+
+    /**
      * Create a new workspace (Root or Child).
      */
     public function createWorkspace(int $userId, array $data): Workspace

--- a/tests/Feature/WorkspaceTest.php
+++ b/tests/Feature/WorkspaceTest.php
@@ -465,3 +465,23 @@ test('moving a child workspace to the same parent does not trigger name conflict
     $response->assertStatus(200)
         ->assertJsonPath('success', true);
 });
+
+test('can retrieve a specific workspace', function () {
+    $workspace = Workspace::factory()->create(['owner_id' => $this->user->id]);
+
+    $response = $this->actingAs($this->user)
+        ->getJson("/api/workspaces/{$workspace->id}");
+
+    $response->assertStatus(200)
+        ->assertJsonPath('success', true)
+        ->assertJsonPath('data.id', $workspace->id);
+});
+
+test('unauthorized users cannot view other users workspaces', function () {
+    $workspace = Workspace::factory()->create(['owner_id' => $this->otherUser->id]);
+
+    $response = $this->actingAs($this->user)
+        ->getJson("/api/workspaces/{$workspace->id}");
+
+    $response->assertStatus(403);
+});


### PR DESCRIPTION
Implement the missing `show` method in `WorkspaceController` and `WorkspaceService` to resolve the 500 error when accessing individual workspaces. Includes ownership validation and tests. Closes #32