### PR TITLE
[Feature] Eager load child workspaces in show response

### DIFF
--- a/app/Services/WorkspaceService.php
+++ b/app/Services/WorkspaceService.php
@@ -32,6 +32,9 @@ class WorkspaceService
             throw new Exception('Unauthorized to access this workspace.', 403);
         }
 
+        // Eager load child workspaces to show contents
+        $workspace->load('children');
+
         return $workspace;
     }
 

--- a/tests/Feature/WorkspaceTest.php
+++ b/tests/Feature/WorkspaceTest.php
@@ -485,3 +485,19 @@ test('unauthorized users cannot view other users workspaces', function () {
 
     $response->assertStatus(403);
 });
+
+test('retrieving a workspace includes its children', function () {
+    $parent = Workspace::factory()->create(['owner_id' => $this->user->id]);
+    $child = Workspace::factory()->create([
+        'owner_id' => $this->user->id,
+        'parent_id' => $parent->id,
+    ]);
+
+    $response = $this->actingAs($this->user)
+        ->getJson("/api/workspaces/{$parent->id}");
+
+    $response->assertStatus(200)
+        ->assertJsonCount(1, 'data.children')
+        ->assertJsonPath('data.children.0.id', $child->id);
+});
+


### PR DESCRIPTION
Modify `WorkspaceService::findWorkspace` to eager load the `children` relationship. This allows users to see sub-workspaces when fetching a parent workspace via the `show` endpoint.