### PR TITLE
[Feature] Add root-only workspace retrieval endpoint

### DIFF
--- a/app/Http/Controllers/WorkspaceController.php
+++ b/app/Http/Controllers/WorkspaceController.php
@@ -27,6 +27,16 @@ class WorkspaceController extends Controller
     }
 
     /**
+     * Display a listing of root workspaces (parent_id is null).
+     */
+    public function root(): JsonResponse
+    {
+        $workspaces = $this->service->getRootWorkspaces(Auth::id());
+
+        return ApiResponse::success($workspaces, 'Root workspaces retrieved successfully');
+    }
+
+    /**
      * Store a newly created workspace in storage.
      */
     public function store(StoreWorkspaceRequest $request): JsonResponse

--- a/app/Repositories/WorkspaceRepository.php
+++ b/app/Repositories/WorkspaceRepository.php
@@ -50,6 +50,16 @@ class WorkspaceRepository
     }
 
     /**
+     * Get root workspaces owned by a user.
+     */
+    public function getRootByOwner(int $ownerId): Collection
+    {
+        return Workspace::where('owner_id', $ownerId)
+            ->whereNull('parent_id')
+            ->get();
+    }
+
+    /**
      * Find a workspace by owner, parent, and name (for uniqueness check).
      */
     public function findByNameAndParent(int $ownerId, ?int $parentId, string $name): ?Workspace

--- a/app/Services/WorkspaceService.php
+++ b/app/Services/WorkspaceService.php
@@ -22,6 +22,14 @@ class WorkspaceService
     }
 
     /**
+     * Get root workspaces for the authenticated user.
+     */
+    public function getRootWorkspaces(int $userId): Collection
+    {
+        return $this->repository->getRootByOwner($userId);
+    }
+
+    /**
      * Find a specific workspace with ownership validation.
      */
     public function findWorkspace(int $userId, int $id): Workspace

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,6 +16,8 @@ Route::middleware('auth:sanctum')->group(function () {
         return ApiResponse::success($request->user(), 'Authenticated user');
     });
 
+    Route::get('/workspaces/root', [WorkspaceController::class, 'root']);
     Route::apiResource('/workspaces', WorkspaceController::class);
     Route::patch('/workspaces/{id}/move', [WorkspaceController::class, 'move']);
+
 });

--- a/tests/Feature/WorkspaceTest.php
+++ b/tests/Feature/WorkspaceTest.php
@@ -501,3 +501,20 @@ test('retrieving a workspace includes its children', function () {
         ->assertJsonPath('data.children.0.id', $child->id);
 });
 
+test('can retrieve only root workspaces', function () {
+    $root = Workspace::factory()->create([
+        'owner_id' => $this->user->id,
+        'parent_id' => null,
+    ]);
+    Workspace::factory()->create([
+        'owner_id' => $this->user->id,
+        'parent_id' => $root->id,
+    ]);
+
+    $response = $this->actingAs($this->user)
+        ->getJson('/api/workspaces/root');
+
+    $response->assertStatus(200)
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.id', $root->id);
+});


### PR DESCRIPTION
Add a new endpoint `GET /api/workspaces/root` to retrieve only workspaces at the root level (`parent_id = null`). This allows for cleaner dashboard navigation. Implementation follows the Controller -> Service -> Repository pattern.