### PR TITLE
[Feature] Implement Trash List API for Workspaces

### DIFF
--- a/app/Http/Controllers/WorkspaceController.php
+++ b/app/Http/Controllers/WorkspaceController.php
@@ -18,6 +18,16 @@ class WorkspaceController extends Controller
     ) {}
 
     /**
+     * Display a listing of trashed workspaces.
+     */
+    public function trash(): JsonResponse
+    {
+        $workspaces = $this->service->getTrashedWorkspaces(Auth::id());
+
+        return ApiResponse::success($workspaces, 'Trashed workspaces retrieved successfully');
+    }
+
+    /**
      * Display a listing of the workspaces.
      */
     public function index(): JsonResponse

--- a/app/Repositories/WorkspaceRepository.php
+++ b/app/Repositories/WorkspaceRepository.php
@@ -151,4 +151,14 @@ class WorkspaceRepository
             $this->updateSubtreeDepths($child, $newDepth + 1);
         }
     }
+
+    /**
+     * Get all soft-deleted workspaces for a specific owner.
+     */
+    public function getTrashedByOwner(int $ownerId): Collection
+    {
+        return Workspace::onlyTrashed()
+            ->where('owner_id', $ownerId)
+            ->get();
+    }
 }

--- a/app/Services/WorkspaceService.php
+++ b/app/Services/WorkspaceService.php
@@ -199,6 +199,14 @@ class WorkspaceService
     }
 
     /**
+     * Get all trashed workspaces for a user.
+     */
+    public function getTrashedWorkspaces(int $userId): Collection
+    {
+        return $this->repository->getTrashedByOwner($userId);
+    }
+
+    /**
      * Restore a soft-deleted workspace and all its descendants.
      */
     public function restoreWorkspace(int $userId, int $id): Workspace

--- a/routes/api.php
+++ b/routes/api.php
@@ -17,7 +17,9 @@ Route::middleware('auth:sanctum')->group(function () {
     });
 
     Route::get('/workspaces/root', [WorkspaceController::class, 'root']);
+    Route::get('/workspaces/trash', [WorkspaceController::class, 'trash']);
     Route::apiResource('/workspaces', WorkspaceController::class);
+
     Route::patch('/workspaces/{id}/move', [WorkspaceController::class, 'move']);
     Route::post('/workspaces/{workspace}/restore', [WorkspaceController::class, 'restore'])->withTrashed();
 

--- a/tests/Feature/WorkspaceTest.php
+++ b/tests/Feature/WorkspaceTest.php
@@ -558,7 +558,25 @@ test('can restore a soft-deleted workspace and its children', function () {
     $this->assertDatabaseHas('workspaces', ['id' => $parent->id, 'deleted_at' => null]);
     $this->assertDatabaseHas('workspaces', ['id' => $child->id, 'deleted_at' => null]);
 
-    // Ensure they are visible again
     $indexResponse = $this->actingAs($this->user)->getJson('/api/workspaces');
     $indexResponse->assertStatus(200)->assertJsonCount(2, 'data');
+});
+
+test('can retrieve a list of trashed workspaces', function () {
+    $workspace = Workspace::factory()->create(['owner_id' => $this->user->id]);
+    $otherWorkspace = Workspace::factory()->create(['owner_id' => $this->user->id]);
+    $trashWorkspace = Workspace::factory()->create(['owner_id' => $this->user->id]);
+    $otherUserWorkspace = Workspace::factory()->create(['owner_id' => $this->otherUser->id]);
+
+    // Soft delete one
+    $trashWorkspace->delete();
+    $otherUserWorkspace->delete();
+
+    $response = $this->actingAs($this->user)
+        ->getJson('/api/workspaces/trash');
+
+    $response->assertStatus(200)
+        ->assertJsonPath('success', true)
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.id', $trashWorkspace->id);
 });


### PR DESCRIPTION
## Description
Implemented Trash List API to allow users to view soft-deleted workspaces.

Closes #44

## Key Changes
- **Repository**: Added  method.
- **Service**: Added  method.
- **Controller**: Added  endpoint.
- **Router**: Registered  route.

## Testing Status
- 33 test cases passed (PASS).
- Verified that only trashed workspaces owned by the user are returned.