### PR TITLE
[Bugfix] Fix Unique Constraint Violation With Soft Deletes

### DIFF
--- a/app/Services/WorkspaceService.php
+++ b/app/Services/WorkspaceService.php
@@ -217,6 +217,13 @@ class WorkspaceService
             abort(403, 'Unauthorized to restore this workspace.');
         }
 
+        if ($this->repository->findByNameAndParent($userId, $workspace->parent_id, $workspace->name)) {
+            $levelMessage = $workspace->parent_id ? 'at this parent level' : 'at the root level';
+            throw ValidationException::withMessages([
+                'name' => ["Cannot restore workspace because an active workspace with this name already exists {$levelMessage}."],
+            ]);
+        }
+
         $this->performRecursiveRestore($workspace);
 
         return $workspace->refresh();

--- a/database/migrations/2026_03_24_104334_drop_unique_constraint_from_workspaces_table.php
+++ b/database/migrations/2026_03_24_104334_drop_unique_constraint_from_workspaces_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('workspaces', function (Blueprint $table) {
+            $table->dropUnique(['owner_id', 'parent_id', 'name']);
+        });
+
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('workspaces', function (Blueprint $table) {
+            $table->unique(['owner_id', 'parent_id', 'name']);
+        });
+
+    }
+};

--- a/tests/Feature/WorkspaceTest.php
+++ b/tests/Feature/WorkspaceTest.php
@@ -580,3 +580,50 @@ test('can retrieve a list of trashed workspaces', function () {
         ->assertJsonCount(1, 'data')
         ->assertJsonPath('data.0.id', $trashWorkspace->id);
 });
+
+test('can create a workspace with a name of a soft-deleted workspace', function () {
+    $workspace = Workspace::factory()->create([
+        'name' => 'Soft Deleted Name',
+        'owner_id' => $this->user->id,
+        'parent_id' => null,
+    ]);
+
+    // Soft delete the workspace
+    $this->actingAs($this->user)->deleteJson("/api/workspaces/{$workspace->id}");
+
+    // Create a new one with the exact same name
+    $response = $this->actingAs($this->user)
+        ->postJson('/api/workspaces', [
+            'name' => 'Soft Deleted Name',
+            'parent_id' => null,
+        ]);
+
+    $response->assertStatus(201)
+        ->assertJsonPath('success', true);
+});
+
+test('cannot restore a workspace if an active workspace has the same name', function () {
+    $workspace = Workspace::factory()->create([
+        'name' => 'Conflict Name',
+        'owner_id' => $this->user->id,
+        'parent_id' => null,
+    ]);
+
+    // Soft delete it
+    $this->actingAs($this->user)->deleteJson("/api/workspaces/{$workspace->id}");
+
+    // Create an active one with the same name
+    Workspace::factory()->create([
+        'name' => 'Conflict Name',
+        'owner_id' => $this->user->id,
+        'parent_id' => null,
+    ]);
+
+    // Try to restore the soft-deleted one
+    $response = $this->actingAs($this->user)
+        ->postJson("/api/workspaces/{$workspace->id}/restore");
+
+    $response->assertStatus(422)
+        ->assertJsonPath('success', false)
+        ->assertJsonPath('message', 'Cannot restore workspace because an active workspace with this name already exists at the root level.');
+});


### PR DESCRIPTION
## Description
Fixes the 500 error when reusing names of soft-deleted workspaces by removing the physical database constraint and validating collisions dynamically at the Service layer.

Closes #46

## Key Changes
- **Migration**: Dropped the unique constraint on `owner_id`, `parent_id`, `name` from `workspaces`.
- **Service**: Added a name collision check in `restoreWorkspace` that throws a ValidationException.
- **Tests**: Added tests to ensure soft-deleted names can be reused, and that restoring overlapping names correctly throws 422.

## Testing Status
- 35 test cases passed (PASS).