### PR TITLE
feat: Implement Workspace Archive and Visual Settings

### DIFF
--- a/app/Http/Controllers/WorkspaceController.php
+++ b/app/Http/Controllers/WorkspaceController.php
@@ -28,11 +28,23 @@ class WorkspaceController extends Controller
     }
 
     /**
+     * Display a listing of archived workspaces.
+     */
+    public function archived(): JsonResponse
+    {
+        $workspaces = $this->service->getWorkspaces(Auth::id(), true);
+        $archived = $workspaces->filter(fn ($w) => $w->is_archived)->values();
+
+        return ApiResponse::success($archived, 'Archived workspaces retrieved successfully');
+    }
+
+    /**
      * Display a listing of the workspaces.
      */
     public function index(): JsonResponse
     {
-        $workspaces = $this->service->getWorkspaces(Auth::id());
+        $includeArchived = request()->boolean('include_archived');
+        $workspaces = $this->service->getWorkspaces(Auth::id(), $includeArchived);
 
         return ApiResponse::success($workspaces, 'Workspaces retrieved successfully');
     }
@@ -42,7 +54,8 @@ class WorkspaceController extends Controller
      */
     public function root(): JsonResponse
     {
-        $workspaces = $this->service->getRootWorkspaces(Auth::id());
+        $includeArchived = request()->boolean('include_archived');
+        $workspaces = $this->service->getRootWorkspaces(Auth::id(), $includeArchived);
 
         return ApiResponse::success($workspaces, 'Root workspaces retrieved successfully');
     }
@@ -62,9 +75,9 @@ class WorkspaceController extends Controller
      */
     public function update(int $id, UpdateWorkspaceRequest $request): JsonResponse
     {
-        $workspace = $this->service->renameWorkspace(Auth::id(), $id, $request->name);
+        $workspace = $this->service->updateWorkspace(Auth::id(), $id, $request->validated());
 
-        return ApiResponse::success($workspace, 'Workspace renamed successfully');
+        return ApiResponse::success($workspace, 'Workspace updated successfully');
     }
 
     /**
@@ -109,5 +122,16 @@ class WorkspaceController extends Controller
         $workspace = $this->service->restoreWorkspace(Auth::id(), $workspace->id);
 
         return ApiResponse::success($workspace, 'Workspace restored successfully');
+    }
+
+    /**
+     * Toggle archive status of a workspace.
+     */
+    public function archive(int $id): JsonResponse
+    {
+        $workspace = $this->service->archiveWorkspace(Auth::id(), $id);
+        $status = $workspace->is_archived ? 'archived' : 'unarchived';
+
+        return ApiResponse::success($workspace, "Workspace {$status} successfully");
     }
 }

--- a/app/Http/Controllers/WorkspaceController.php
+++ b/app/Http/Controllers/WorkspaceController.php
@@ -32,8 +32,7 @@ class WorkspaceController extends Controller
      */
     public function archived(): JsonResponse
     {
-        $workspaces = $this->service->getWorkspaces(Auth::id(), true);
-        $archived = $workspaces->filter(fn ($w) => $w->is_archived)->values();
+        $archived = $this->service->getArchivedWorkspaces(Auth::id());
 
         return ApiResponse::success($archived, 'Archived workspaces retrieved successfully');
     }

--- a/app/Http/Requests/StoreWorkspaceRequest.php
+++ b/app/Http/Requests/StoreWorkspaceRequest.php
@@ -25,8 +25,6 @@ class StoreWorkspaceRequest extends FormRequest
             'parent_id' => ['nullable', 'integer', Rule::exists('workspaces', 'id')->whereNull('deleted_at')],
             'icon' => ['nullable', 'string', 'max:50'],
             'color' => ['nullable', 'string', 'regex:/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/'],
-            'is_archived' => ['boolean'],
-
         ];
     }
 }

--- a/app/Http/Requests/StoreWorkspaceRequest.php
+++ b/app/Http/Requests/StoreWorkspaceRequest.php
@@ -23,6 +23,9 @@ class StoreWorkspaceRequest extends FormRequest
         return [
             'name' => ['required', 'string', 'max:255'],
             'parent_id' => ['nullable', 'integer', Rule::exists('workspaces', 'id')->whereNull('deleted_at')],
+            'icon' => ['nullable', 'string', 'max:50'],
+            'color' => ['nullable', 'string', 'regex:/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/'],
+            'is_archived' => ['boolean'],
 
         ];
     }

--- a/app/Http/Requests/UpdateWorkspaceRequest.php
+++ b/app/Http/Requests/UpdateWorkspaceRequest.php
@@ -21,6 +21,10 @@ class UpdateWorkspaceRequest extends FormRequest
     {
         return [
             'name' => ['sometimes', 'required', 'string', 'max:255'],
+            'icon' => ['sometimes', 'nullable', 'string', 'max:50'],
+            'color' => ['sometimes', 'nullable', 'string', 'regex:/^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/'],
+            'is_archived' => ['sometimes', 'boolean'],
+
         ];
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -8,8 +8,8 @@ use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
-use Laravel\Sanctum\HasApiTokens;
 use Illuminate\Notifications\Notifiable;
+use Laravel\Sanctum\HasApiTokens;
 
 #[Fillable(['name', 'email', 'password'])]
 #[Hidden(['password', 'remember_token'])]

--- a/app/Models/Workspace.php
+++ b/app/Models/Workspace.php
@@ -14,7 +14,13 @@ class Workspace extends Model
     /** @use HasFactory<WorkspaceFactory> */
     use HasFactory, SoftDeletes;
 
+    public const DEFAULT_SETTINGS = [
+        'icon' => 'folder_open',
+        'color' => '#A0AEC0', // Neutral Gray/Silver
+    ];
+
     protected $fillable = [
+
         'name',
         'owner_id',
         'parent_id',

--- a/app/Models/Workspace.php
+++ b/app/Models/Workspace.php
@@ -15,8 +15,8 @@ class Workspace extends Model
     use HasFactory, SoftDeletes;
 
     public const DEFAULT_SETTINGS = [
-        'icon' => 'folder_open',
-        'color' => '#A0AEC0', // Neutral Gray/Silver
+        'icon' => null,
+        'color' => null,
     ];
 
     protected $fillable = [

--- a/app/Models/Workspace.php
+++ b/app/Models/Workspace.php
@@ -19,7 +19,22 @@ class Workspace extends Model
         'owner_id',
         'parent_id',
         'depth',
+        'is_archived',
+        'settings',
     ];
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'is_archived' => 'boolean',
+            'settings' => 'array',
+        ];
+    }
 
     /**
      * Get the user that owns the workspace.

--- a/app/Repositories/WorkspaceRepository.php
+++ b/app/Repositories/WorkspaceRepository.php
@@ -180,6 +180,9 @@ class WorkspaceRepository
     {
         return Workspace::where('owner_id', $ownerId)
             ->where('is_archived', true)
+            ->whereDoesntHave('parent', function ($query) {
+                $query->where('is_archived', true);
+            })
             ->get();
     }
 }

--- a/app/Repositories/WorkspaceRepository.php
+++ b/app/Repositories/WorkspaceRepository.php
@@ -174,15 +174,26 @@ class WorkspaceRepository
     }
 
     /**
-     * Get all archived workspaces for a specific owner.
+     * Get all archived workspaces for a specific owner (top-level only).
+     * Returns only archived workspaces whose parent is not archived.
      */
     public function getArchivedByOwner(int $ownerId): Collection
     {
         return Workspace::where('owner_id', $ownerId)
             ->where('is_archived', true)
             ->whereDoesntHave('parent', function ($query) {
-                $query->where('is_archived', true);
+                $query->withTrashed()->where('is_archived', true);
             })
             ->get();
+    }
+
+    /**
+     * Bulk update the archive status for a list of workspace IDs.
+     *
+     * @param  array<int>  $ids
+     */
+    public function bulkUpdateArchiveStatus(array $ids, bool $status): void
+    {
+        Workspace::withTrashed()->whereIn('id', $ids)->update(['is_archived' => $status]);
     }
 }

--- a/app/Repositories/WorkspaceRepository.php
+++ b/app/Repositories/WorkspaceRepository.php
@@ -60,19 +60,30 @@ class WorkspaceRepository
     /**
      * Get all workspaces owned by a user.
      */
-    public function getByOwner(int $ownerId): Collection
+    public function getByOwner(int $ownerId, bool $includeArchived = false): Collection
     {
-        return Workspace::where('owner_id', $ownerId)->get();
+        $query = Workspace::where('owner_id', $ownerId);
+
+        if (! $includeArchived) {
+            $query->where('is_archived', false);
+        }
+
+        return $query->get();
     }
 
     /**
      * Get root workspaces owned by a user.
      */
-    public function getRootByOwner(int $ownerId): Collection
+    public function getRootByOwner(int $ownerId, bool $includeArchived = false): Collection
     {
-        return Workspace::where('owner_id', $ownerId)
-            ->whereNull('parent_id')
-            ->get();
+        $query = Workspace::where('owner_id', $ownerId)
+            ->whereNull('parent_id');
+
+        if (! $includeArchived) {
+            $query->where('is_archived', false);
+        }
+
+        return $query->get();
     }
 
     /**
@@ -159,6 +170,16 @@ class WorkspaceRepository
     {
         return Workspace::onlyTrashed()
             ->where('owner_id', $ownerId)
+            ->get();
+    }
+
+    /**
+     * Get all archived workspaces for a specific owner.
+     */
+    public function getArchivedByOwner(int $ownerId): Collection
+    {
+        return Workspace::where('owner_id', $ownerId)
+            ->where('is_archived', true)
             ->get();
     }
 }

--- a/app/Services/WorkspaceService.php
+++ b/app/Services/WorkspaceService.php
@@ -31,6 +31,14 @@ class WorkspaceService
     }
 
     /**
+     * Get isolated/top-level archived workspaces for the authenticated user.
+     */
+    public function getArchivedWorkspaces(int $userId): Collection
+    {
+        return $this->repository->getArchivedByOwner($userId);
+    }
+
+    /**
      * Find a specific workspace with ownership validation.
      */
     public function findWorkspace(int $userId, int $id): Workspace

--- a/app/Services/WorkspaceService.php
+++ b/app/Services/WorkspaceService.php
@@ -128,11 +128,6 @@ class WorkspaceService
             $updateData['name'] = $data['name'];
         }
 
-        if (isset($data['is_archived']) && $data['is_archived'] !== $workspace->is_archived) {
-            $this->performRecursiveArchive($workspace, $data['is_archived']);
-            $updateData['is_archived'] = $data['is_archived'];
-        }
-
         // Handle settings merging
 
         if (isset($data['icon']) || isset($data['color'])) {
@@ -167,7 +162,7 @@ class WorkspaceService
         $workspace = $this->repository->findOrFail($id);
 
         if ($workspace->owner_id !== $userId) {
-            abort(403, 'Unauthorized to archive this workspace.');
+            throw new Exception('Unauthorized to archive this workspace.', 403);
         }
 
         $newStatus = ! $workspace->is_archived;
@@ -179,19 +174,35 @@ class WorkspaceService
     }
 
     /**
-     * Helper to recursively archive or unarchive descendants.
+     * Helper to recursively collect all descendant IDs and bulk-update archive status.
      */
     protected function performRecursiveArchive(Workspace $workspace, bool $status): void
     {
-        // Load children (including trashed) to ensure the whole subtree is consistent
+        $ids = $this->collectDescendantIds($workspace);
+
+        if (! empty($ids)) {
+            $this->repository->bulkUpdateArchiveStatus($ids, $status);
+        }
+    }
+
+    /**
+     * Recursively collect IDs of all descendants.
+     *
+     * @return array<int>
+     */
+    protected function collectDescendantIds(Workspace $workspace): array
+    {
         $workspace->load(['children' => function ($query) {
             $query->withTrashed();
         }]);
 
+        $ids = [];
         foreach ($workspace->children as $child) {
-            $this->performRecursiveArchive($child, $status);
-            $this->repository->update($child, ['is_archived' => $status]);
+            $ids[] = $child->id;
+            $ids = array_merge($ids, $this->collectDescendantIds($child));
         }
+
+        return $ids;
     }
 
     /**
@@ -202,7 +213,7 @@ class WorkspaceService
         $workspace = $this->repository->findOrFail($id);
 
         if ($workspace->owner_id !== $userId) {
-            abort(403, 'Unauthorized to delete this workspace.');
+            throw new Exception('Unauthorized to delete this workspace.', 403);
         }
 
         $this->performRecursiveDelete($workspace);

--- a/app/Services/WorkspaceService.php
+++ b/app/Services/WorkspaceService.php
@@ -17,17 +17,17 @@ class WorkspaceService
     /**
      * Get all workspaces for the authenticated user.
      */
-    public function getWorkspaces(int $userId): Collection
+    public function getWorkspaces(int $userId, bool $includeArchived = false): Collection
     {
-        return $this->repository->getByOwner($userId);
+        return $this->repository->getByOwner($userId, $includeArchived);
     }
 
     /**
      * Get root workspaces for the authenticated user.
      */
-    public function getRootWorkspaces(int $userId): Collection
+    public function getRootWorkspaces(int $userId, bool $includeArchived = false): Collection
     {
-        return $this->repository->getRootByOwner($userId);
+        return $this->repository->getRootByOwner($userId, $includeArchived);
     }
 
     /**
@@ -78,18 +78,28 @@ class WorkspaceService
             ]);
         }
 
+        $settings = null;
+        if (isset($data['icon']) || isset($data['color'])) {
+            $settings = [
+                'icon' => $data['icon'] ?? null,
+                'color' => $data['color'] ?? null,
+            ];
+        }
+
         return $this->repository->create([
             'name' => $data['name'],
             'owner_id' => $userId,
             'parent_id' => $parentId,
             'depth' => $depth,
+            'settings' => $settings,
+            'is_archived' => $data['is_archived'] ?? false,
         ]);
     }
 
     /**
-     * Rename an existing workspace.
+     * Update an existing workspace.
      */
-    public function renameWorkspace(int $userId, int $id, string $name): Workspace
+    public function updateWorkspace(int $userId, int $id, array $data): Workspace
     {
         $workspace = $this->repository->findOrFail($id);
 
@@ -97,16 +107,61 @@ class WorkspaceService
             throw new Exception('Unauthorized to update this workspace.', 403);
         }
 
-        if ($name !== $workspace->name) {
-            if ($this->repository->findByNameAndParent($userId, $workspace->parent_id, $name)) {
+        $updateData = [];
+
+        if (isset($data['name']) && $data['name'] !== $workspace->name) {
+            if ($this->repository->findByNameAndParent($userId, $workspace->parent_id, $data['name'])) {
                 $levelMessage = $workspace->parent_id ? 'at this parent level' : 'at the root level';
                 throw ValidationException::withMessages([
                     'name' => ["A workspace with this name already exists {$levelMessage}."],
                 ]);
             }
+            $updateData['name'] = $data['name'];
         }
 
-        return $this->repository->update($workspace, ['name' => $name]);
+        if (isset($data['is_archived'])) {
+            $updateData['is_archived'] = $data['is_archived'];
+        }
+
+        // Handle settings merging
+        if (isset($data['icon']) || isset($data['color'])) {
+            $settings = $workspace->settings ?? [];
+            if (isset($data['icon'])) {
+                $settings['icon'] = $data['icon'];
+            }
+            if (isset($data['color'])) {
+                $settings['color'] = $data['color'];
+            }
+            $updateData['settings'] = $settings;
+        }
+
+        return $this->repository->update($workspace, $updateData);
+    }
+
+    /**
+     * Rename an existing workspace.
+     *
+     * @deprecated Use updateWorkspace instead
+     */
+    public function renameWorkspace(int $userId, int $id, string $name): Workspace
+    {
+        return $this->updateWorkspace($userId, $id, ['name' => $name]);
+    }
+
+    /**
+     * Toggle archive status of a workspace.
+     */
+    public function archiveWorkspace(int $userId, int $id): Workspace
+    {
+        $workspace = $this->repository->findOrFail($id);
+
+        if ($workspace->owner_id !== $userId) {
+            abort(403, 'Unauthorized to archive this workspace.');
+        }
+
+        return $this->repository->update($workspace, [
+            'is_archived' => ! $workspace->is_archived,
+        ]);
     }
 
     /**

--- a/app/Services/WorkspaceService.php
+++ b/app/Services/WorkspaceService.php
@@ -78,15 +78,16 @@ class WorkspaceService
             ]);
         }
 
-        $settings = null;
-        if (isset($data['icon']) || isset($data['color'])) {
-            $settings = [
-                'icon' => $data['icon'] ?? null,
-                'color' => $data['color'] ?? null,
-            ];
+        $settings = Workspace::DEFAULT_SETTINGS;
+        if (isset($data['icon'])) {
+            $settings['icon'] = $data['icon'];
+        }
+        if (isset($data['color'])) {
+            $settings['color'] = $data['color'];
         }
 
         return $this->repository->create([
+
             'name' => $data['name'],
             'owner_id' => $userId,
             'parent_id' => $parentId,

--- a/app/Services/WorkspaceService.php
+++ b/app/Services/WorkspaceService.php
@@ -120,11 +120,13 @@ class WorkspaceService
             $updateData['name'] = $data['name'];
         }
 
-        if (isset($data['is_archived'])) {
+        if (isset($data['is_archived']) && $data['is_archived'] !== $workspace->is_archived) {
+            $this->performRecursiveArchive($workspace, $data['is_archived']);
             $updateData['is_archived'] = $data['is_archived'];
         }
 
         // Handle settings merging
+
         if (isset($data['icon']) || isset($data['color'])) {
             $settings = $workspace->settings ?? [];
             if (isset($data['icon'])) {
@@ -160,9 +162,28 @@ class WorkspaceService
             abort(403, 'Unauthorized to archive this workspace.');
         }
 
+        $newStatus = ! $workspace->is_archived;
+        $this->performRecursiveArchive($workspace, $newStatus);
+
         return $this->repository->update($workspace, [
-            'is_archived' => ! $workspace->is_archived,
+            'is_archived' => $newStatus,
         ]);
+    }
+
+    /**
+     * Helper to recursively archive or unarchive descendants.
+     */
+    protected function performRecursiveArchive(Workspace $workspace, bool $status): void
+    {
+        // Load children (including trashed) to ensure the whole subtree is consistent
+        $workspace->load(['children' => function ($query) {
+            $query->withTrashed();
+        }]);
+
+        foreach ($workspace->children as $child) {
+            $this->performRecursiveArchive($child, $status);
+            $this->repository->update($child, ['is_archived' => $status]);
+        }
     }
 
     /**

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -2,11 +2,14 @@
 
 use App\Helpers\ApiResponse;
 use App\Http\Middleware\GuestApi;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -32,14 +35,14 @@ return Application::configure(basePath: dirname(__DIR__))
             }
         });
 
-        $exceptions->render(function (\Throwable $e, Request $request) {
+        $exceptions->render(function (Throwable $e, Request $request) {
             if ($request->is('api/*')) {
-                if ($e instanceof \Illuminate\Database\Eloquent\ModelNotFoundException || $e instanceof \Symfony\Component\HttpKernel\Exception\NotFoundHttpException) {
+                if ($e instanceof ModelNotFoundException || $e instanceof NotFoundHttpException) {
                     return ApiResponse::error('Resource not found.', 404);
                 }
 
                 $statusCode = 500;
-                if ($e instanceof \Symfony\Component\HttpKernel\Exception\HttpExceptionInterface) {
+                if ($e instanceof HttpExceptionInterface) {
                     $statusCode = $e->getStatusCode();
                 } elseif ($e->getCode() >= 400 && $e->getCode() <= 599) {
                     $statusCode = $e->getCode();
@@ -51,6 +54,5 @@ return Application::configure(basePath: dirname(__DIR__))
                 );
             }
         });
-
 
     })->create();

--- a/database/migrations/2026_03_24_123807_add_archive_and_settings_to_workspaces_table.php
+++ b/database/migrations/2026_03_24_123807_add_archive_and_settings_to_workspaces_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('workspaces', function (Blueprint $table) {
+            $table->boolean('is_archived')->default(false)->after('depth');
+            $table->json('settings')->nullable()->after('is_archived');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('workspaces', function (Blueprint $table) {
+            $table->dropColumn(['is_archived', 'settings']);
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -18,9 +18,11 @@ Route::middleware('auth:sanctum')->group(function () {
 
     Route::get('/workspaces/root', [WorkspaceController::class, 'root']);
     Route::get('/workspaces/trash', [WorkspaceController::class, 'trash']);
+    Route::get('/workspaces/archived', [WorkspaceController::class, 'archived']);
     Route::apiResource('/workspaces', WorkspaceController::class);
 
     Route::patch('/workspaces/{id}/move', [WorkspaceController::class, 'move']);
+    Route::patch('/workspaces/{id}/archive', [WorkspaceController::class, 'archive']);
     Route::post('/workspaces/{workspace}/restore', [WorkspaceController::class, 'restore'])->withTrashed();
 
 });

--- a/tests/Feature/WorkspaceTest.php
+++ b/tests/Feature/WorkspaceTest.php
@@ -858,15 +858,27 @@ describe('Workspace Archiving and Settings (#41)', function () {
             ->assertJsonCount(2, 'data');
     });
 
-    it('can retrieve only archived workspaces via dedicated endpoint', function () {
+    it('can retrieve only top-level archived workspaces via dedicated endpoint', function () {
         Workspace::factory()->create(['owner_id' => $this->user->id, 'name' => 'Active', 'is_archived' => false]);
-        Workspace::factory()->create(['owner_id' => $this->user->id, 'name' => 'Archived', 'is_archived' => true]);
+
+        // This is a top-level archived workspace
+        $archivedParent = Workspace::factory()->create(['owner_id' => $this->user->id, 'name' => 'Archived Parent', 'is_archived' => true]);
+        // This is casually archived because of its parent, shouldn't appear in flat list
+        Workspace::factory()->create(['owner_id' => $this->user->id, 'parent_id' => $archivedParent->id, 'name' => 'Archived Child', 'is_archived' => true]);
+
+        // This is archived, but its parent is NOT archived (manual archive of child)
+        $activeParent = Workspace::factory()->create(['owner_id' => $this->user->id, 'name' => 'Active Parent', 'is_archived' => false]);
+        Workspace::factory()->create(['owner_id' => $this->user->id, 'parent_id' => $activeParent->id, 'name' => 'Individually Archived Child', 'is_archived' => true]);
 
         $response = $this->actingAs($this->user)->getJson('/api/workspaces/archived');
 
         $response->assertStatus(200)
-            ->assertJsonCount(1, 'data')
-            ->assertJsonPath('data.0.name', 'Archived');
+            ->assertJsonCount(2, 'data'); // Should only be the Parent and the Individually Archived Child
+
+        $names = collect($response->json('data'))->pluck('name');
+        expect($names)->toContain('Archived Parent')
+            ->toContain('Individually Archived Child')
+            ->not->toContain('Archived Child');
     });
 
     it('validates color hex format', function () {

--- a/tests/Feature/WorkspaceTest.php
+++ b/tests/Feature/WorkspaceTest.php
@@ -888,3 +888,14 @@ describe('Workspace Archiving and Settings (#41)', function () {
             ->assertStatus(403);
     });
 });
+
+it('applies default settings when none are provided', function () {
+    $response = $this->actingAs($this->user)
+        ->postJson('/api/workspaces', [
+            'name' => 'Default Settings WS',
+        ]);
+
+    $response->assertStatus(201)
+        ->assertJsonPath('data.settings.icon', Workspace::DEFAULT_SETTINGS['icon'])
+        ->assertJsonPath('data.settings.color', Workspace::DEFAULT_SETTINGS['color']);
+});

--- a/tests/Feature/WorkspaceTest.php
+++ b/tests/Feature/WorkspaceTest.php
@@ -896,6 +896,6 @@ it('applies default settings when none are provided', function () {
         ]);
 
     $response->assertStatus(201)
-        ->assertJsonPath('data.settings.icon', Workspace::DEFAULT_SETTINGS['icon'])
-        ->assertJsonPath('data.settings.color', Workspace::DEFAULT_SETTINGS['color']);
+        ->assertJsonPath('data.settings.icon', null)
+        ->assertJsonPath('data.settings.color', null);
 });

--- a/tests/Feature/WorkspaceTest.php
+++ b/tests/Feature/WorkspaceTest.php
@@ -764,3 +764,127 @@ test('children hidden from show response after being soft-deleted', function () 
     $response->assertStatus(200)
         ->assertJsonCount(0, 'data.children');
 });
+
+describe('Workspace Archiving and Settings (#41)', function () {
+    beforeEach(function () {
+        $this->user = User::factory()->create();
+    });
+
+    it('can create a workspace with visual settings', function () {
+        $response = $this->actingAs($this->user)
+            ->postJson('/api/workspaces', [
+                'name' => 'Design Workspace',
+                'icon' => 'palette',
+                'color' => '#FF5733',
+            ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.name', 'Design Workspace')
+            ->assertJsonPath('data.settings.icon', 'palette')
+            ->assertJsonPath('data.settings.color', '#FF5733');
+
+        $this->assertDatabaseHas('workspaces', [
+            'name' => 'Design Workspace',
+            'owner_id' => $this->user->id,
+        ]);
+
+        $workspace = Workspace::where('name', 'Design Workspace')->first();
+        expect($workspace->settings)->toBe(['icon' => 'palette', 'color' => '#FF5733']);
+    });
+
+    it('can update workspace visual settings', function () {
+        $workspace = Workspace::factory()->create([
+            'owner_id' => $this->user->id,
+            'settings' => ['icon' => 'old-icon', 'color' => '#000000'],
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->putJson("/api/workspaces/{$workspace->id}", [
+                'icon' => 'new-icon',
+                'color' => '#FFFFFF',
+            ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.settings.icon', 'new-icon')
+            ->assertJsonPath('data.settings.color', '#FFFFFF');
+    });
+
+    it('can toggle archive status', function () {
+        $workspace = Workspace::factory()->create(['owner_id' => $this->user->id]);
+
+        // Archive
+        $this->actingAs($this->user)
+            ->patchJson("/api/workspaces/{$workspace->id}/archive")
+            ->assertStatus(200)
+            ->assertJsonPath('data.is_archived', true);
+
+        expect($workspace->refresh()->is_archived)->toBeTrue();
+
+        // Unarchive
+        $this->actingAs($this->user)
+            ->patchJson("/api/workspaces/{$workspace->id}/archive")
+            ->assertStatus(200)
+            ->assertJsonPath('data.is_archived', false);
+
+        expect($workspace->refresh()->is_archived)->toBeFalse();
+    });
+
+    it('excludes archived workspaces from default list', function () {
+        Workspace::factory()->create([
+            'owner_id' => $this->user->id,
+            'name' => 'Active WS',
+            'is_archived' => false,
+        ]);
+        Workspace::factory()->create([
+            'owner_id' => $this->user->id,
+            'name' => 'Archived WS',
+            'is_archived' => true,
+        ]);
+
+        $response = $this->actingAs($this->user)->getJson('/api/workspaces');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.name', 'Active WS');
+    });
+
+    it('can include archived workspaces in list with query parameter', function () {
+        Workspace::factory()->create(['owner_id' => $this->user->id, 'is_archived' => false]);
+        Workspace::factory()->create(['owner_id' => $this->user->id, 'is_archived' => true]);
+
+        $response = $this->actingAs($this->user)->getJson('/api/workspaces?include_archived=true');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(2, 'data');
+    });
+
+    it('can retrieve only archived workspaces via dedicated endpoint', function () {
+        Workspace::factory()->create(['owner_id' => $this->user->id, 'name' => 'Active', 'is_archived' => false]);
+        Workspace::factory()->create(['owner_id' => $this->user->id, 'name' => 'Archived', 'is_archived' => true]);
+
+        $response = $this->actingAs($this->user)->getJson('/api/workspaces/archived');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.name', 'Archived');
+    });
+
+    it('validates color hex format', function () {
+        $this->actingAs($this->user)
+            ->postJson('/api/workspaces', [
+                'name' => 'Invalid Color',
+                'color' => 'not-a-color',
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['color']);
+    });
+
+    it('prevents unauthorized archive toggle', function () {
+        $otherUser = User::factory()->create();
+        $workspace = Workspace::factory()->create(['owner_id' => $otherUser->id]);
+
+        $this->actingAs($this->user)
+            ->patchJson("/api/workspaces/{$workspace->id}/archive")
+            ->assertStatus(403);
+    });
+});

--- a/tests/Feature/WorkspaceTest.php
+++ b/tests/Feature/WorkspaceTest.php
@@ -899,3 +899,29 @@ it('applies default settings when none are provided', function () {
         ->assertJsonPath('data.settings.icon', null)
         ->assertJsonPath('data.settings.color', null);
 });
+
+it('archives descendants recursively', function () {
+    $parent = Workspace::factory()->create(['owner_id' => $this->user->id]);
+    $child = Workspace::factory()->create(['owner_id' => $this->user->id, 'parent_id' => $parent->id]);
+    $grandchild = Workspace::factory()->create(['owner_id' => $this->user->id, 'parent_id' => $child->id]);
+
+    $this->actingAs($this->user)
+        ->patchJson("/api/workspaces/{$parent->id}/archive")
+        ->assertStatus(200);
+
+    expect($parent->refresh()->is_archived)->toBeTrue();
+    expect($child->refresh()->is_archived)->toBeTrue();
+    expect($grandchild->refresh()->is_archived)->toBeTrue();
+});
+
+it('unarchives descendants recursively', function () {
+    $parent = Workspace::factory()->create(['owner_id' => $this->user->id, 'is_archived' => true]);
+    $child = Workspace::factory()->create(['owner_id' => $this->user->id, 'parent_id' => $parent->id, 'is_archived' => true]);
+
+    $this->actingAs($this->user)
+        ->patchJson("/api/workspaces/{$parent->id}/archive")
+        ->assertStatus(200);
+
+    expect($parent->refresh()->is_archived)->toBeFalse();
+    expect($child->refresh()->is_archived)->toBeFalse();
+});

--- a/tests/Unit/Services/WorkspaceServiceTest.php
+++ b/tests/Unit/Services/WorkspaceServiceTest.php
@@ -12,6 +12,7 @@ use Tests\TestCase;
 class WorkspaceServiceTest extends TestCase
 {
     protected WorkspaceRepository $repository;
+
     protected WorkspaceService $service;
 
     protected function setUp(): void
@@ -24,7 +25,7 @@ class WorkspaceServiceTest extends TestCase
     public function test_it_calculates_depth_one_for_root_workspaces(): void
     {
         Auth::shouldReceive('id')->once()->andReturn(1);
-        
+
         $this->repository->expects($this->once())
             ->method('findByNameAndParent')
             ->with(1, null, 'Root')
@@ -35,7 +36,7 @@ class WorkspaceServiceTest extends TestCase
             ->with($this->callback(function ($data) {
                 return $data['depth'] === 1 && $data['parent_id'] === null;
             }))
-            ->willReturn(new Workspace());
+            ->willReturn(new Workspace);
 
         $this->service->createWorkspace(['name' => 'Root']);
     }
@@ -43,21 +44,21 @@ class WorkspaceServiceTest extends TestCase
     public function test_it_calculates_depth_two_for_child_of_root(): void
     {
         Auth::shouldReceive('id')->andReturn(1);
-        
-        $parent = new Workspace();
+
+        $parent = new Workspace;
         $parent->id = 10;
         $parent->owner_id = 1;
         $parent->depth = 1;
 
         $this->repository->method('findOrFail')->with(10)->willReturn($parent);
         $this->repository->method('findByNameAndParent')->willReturn(null);
-        
+
         $this->repository->expects($this->once())
             ->method('create')
             ->with($this->callback(function ($data) {
                 return $data['depth'] === 2 && $data['parent_id'] === 10;
             }))
-            ->willReturn(new Workspace());
+            ->willReturn(new Workspace);
 
         $this->service->createWorkspace(['name' => 'Level 2', 'parent_id' => 10]);
     }
@@ -65,8 +66,8 @@ class WorkspaceServiceTest extends TestCase
     public function test_it_throws_exception_when_depth_exceeds_three(): void
     {
         Auth::shouldReceive('id')->andReturn(1);
-        
-        $parent = new Workspace();
+
+        $parent = new Workspace;
         $parent->id = 20;
         $parent->owner_id = 1;
         $parent->depth = 3;
@@ -82,8 +83,8 @@ class WorkspaceServiceTest extends TestCase
     public function test_it_throws_exception_when_parent_belongs_to_another_user(): void
     {
         Auth::shouldReceive('id')->andReturn(1);
-        
-        $parent = new Workspace();
+
+        $parent = new Workspace;
         $parent->id = 30;
         $parent->owner_id = 2; // Different user
         $parent->depth = 1;


### PR DESCRIPTION
## Summary
This PR implements Issue #41, which adds archiving capabilities and visual settings (icon and color) to Workspaces.

### Changes
- **Database**: Added  (boolean) and  (JSON) columns to  table.
- **Model**: Updated  model with appropriate  and  handling.
- **Logic**: 
  - Archiving a workspace now recursively archives all its descendants.
  - The  endpoint was refactored to only return **top-level** archived workspaces (archived workspaces whose parents are NOT archived), keeping the list clean and organized.
  - Global filters in  automatically exclude archived workspaces from standard lists.
- **API**: Updated Store and Update requests to support , , and .
- **Testing**: Added comprehensive Pest tests covering recursion, filtering, and visual settings validation.

Closes #41.