### PR TITLE
feat: Implement Summary/Counter for Workspace API Responses

### DIFF
--- a/app/Repositories/WorkspaceRepository.php
+++ b/app/Repositories/WorkspaceRepository.php
@@ -62,7 +62,8 @@ class WorkspaceRepository
      */
     public function getByOwner(int $ownerId, bool $includeArchived = false): Collection
     {
-        $query = Workspace::where('owner_id', $ownerId);
+        $query = Workspace::withCount('children')
+            ->where('owner_id', $ownerId);
 
         if (! $includeArchived) {
             $query->where('is_archived', false);
@@ -76,7 +77,8 @@ class WorkspaceRepository
      */
     public function getRootByOwner(int $ownerId, bool $includeArchived = false): Collection
     {
-        $query = Workspace::where('owner_id', $ownerId)
+        $query = Workspace::withCount('children')
+            ->where('owner_id', $ownerId)
             ->whereNull('parent_id');
 
         if (! $includeArchived) {

--- a/app/Services/WorkspaceService.php
+++ b/app/Services/WorkspaceService.php
@@ -49,8 +49,9 @@ class WorkspaceService
             throw new Exception('Unauthorized to access this workspace.', 403);
         }
 
-        // Eager load child workspaces to show contents
+        // Eager load child workspaces and their count
         $workspace->load('children');
+        $workspace->loadCount('children');
 
         return $workspace;
     }

--- a/tests/Feature/WorkspaceTest.php
+++ b/tests/Feature/WorkspaceTest.php
@@ -775,8 +775,10 @@ describe('Workspace Summary Counter (#39)', function () {
 
         $response = $this->actingAs($this->user)->getJson('/api/workspaces');
 
-        $response->assertStatus(200)
-            ->assertJsonPath('data.0.children_count', 3);
+        $response->assertStatus(200);
+
+        $parentData = collect($response->json('data'))->firstWhere('id', $parent->id);
+        expect($parentData['children_count'])->toBe(3);
     });
 
     it('includes children_count as 0 when workspace has no children', function () {

--- a/tests/Feature/WorkspaceTest.php
+++ b/tests/Feature/WorkspaceTest.php
@@ -765,7 +765,58 @@ test('children hidden from show response after being soft-deleted', function () 
         ->assertJsonCount(0, 'data.children');
 });
 
+describe('Workspace Summary Counter (#39)', function () {
+    it('includes children_count in the index response', function () {
+        $parent = Workspace::factory()->create(['owner_id' => $this->user->id]);
+        Workspace::factory()->count(3)->create([
+            'owner_id' => $this->user->id,
+            'parent_id' => $parent->id,
+        ]);
+
+        $response = $this->actingAs($this->user)->getJson('/api/workspaces');
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.0.children_count', 3);
+    });
+
+    it('includes children_count as 0 when workspace has no children', function () {
+        Workspace::factory()->create(['owner_id' => $this->user->id]);
+
+        $response = $this->actingAs($this->user)->getJson('/api/workspaces');
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.0.children_count', 0);
+    });
+
+    it('includes children_count in the root response', function () {
+        $root = Workspace::factory()->create(['owner_id' => $this->user->id, 'parent_id' => null]);
+        Workspace::factory()->count(2)->create([
+            'owner_id' => $this->user->id,
+            'parent_id' => $root->id,
+        ]);
+
+        $response = $this->actingAs($this->user)->getJson('/api/workspaces/root');
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.0.children_count', 2);
+    });
+
+    it('includes children_count in the show response', function () {
+        $parent = Workspace::factory()->create(['owner_id' => $this->user->id]);
+        Workspace::factory()->count(2)->create([
+            'owner_id' => $this->user->id,
+            'parent_id' => $parent->id,
+        ]);
+
+        $response = $this->actingAs($this->user)->getJson("/api/workspaces/{$parent->id}");
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.children_count', 2);
+    });
+});
+
 describe('Workspace Archiving and Settings (#41)', function () {
+
     beforeEach(function () {
         $this->user = User::factory()->create();
     });


### PR DESCRIPTION
## Summary
Implements Issue #39 by adding `children_count` to workspace API responses.

### Changes
- **`WorkspaceRepository::getByOwner`**: Added `withCount('children')`
- **`WorkspaceRepository::getRootByOwner`**: Added `withCount('children')`
- **`WorkspaceService::findWorkspace`**: Added `loadCount('children')` alongside `load('children')`

### Endpoints Updated
- `GET /api/workspaces` — each item now includes `children_count`
- `GET /api/workspaces/root` — each item now includes `children_count`
- `GET /api/workspaces/{id}` — response now includes `children_count`

### Testing
Added 4 new Pest feature tests:
- `children_count` on index endpoint
- `children_count` is 0 when no children exist
- `children_count` on root endpoint
- `children_count` on show endpoint

61 tests total, all passing.

Closes #39.