### PR TITLE
feat: Implement Breadcrumbs API for Workspace Navigation

### DIFF
--- a/app/Http/Controllers/WorkspaceController.php
+++ b/app/Http/Controllers/WorkspaceController.php
@@ -133,4 +133,14 @@ class WorkspaceController extends Controller
 
         return ApiResponse::success($workspace, "Workspace {$status} successfully");
     }
+
+    /**
+     * Get breadcrumbs (ancestor path) for a specific workspace.
+     */
+    public function breadcrumbs(int $id): JsonResponse
+    {
+        $breadcrumbs = $this->service->getBreadcrumbs(Auth::id(), $id);
+
+        return ApiResponse::success($breadcrumbs, 'Breadcrumbs retrieved successfully');
+    }
 }

--- a/app/Repositories/WorkspaceRepository.php
+++ b/app/Repositories/WorkspaceRepository.php
@@ -198,4 +198,25 @@ class WorkspaceRepository
     {
         Workspace::withTrashed()->whereIn('id', $ids)->update(['is_archived' => $status]);
     }
+
+    /**
+     * Get the ancestors of a workspace from root down to the workspace itself.
+     *
+     * @return array<int, array{id: int, name: string}>
+     */
+    public function getAncestors(Workspace $workspace): array
+    {
+        $ancestors = [];
+        $current = $workspace;
+
+        while ($current !== null) {
+            array_unshift($ancestors, [
+                'id' => $current->id,
+                'name' => $current->name,
+            ]);
+            $current = $current->parent_id ? $this->findOrFail($current->parent_id) : null;
+        }
+
+        return $ancestors;
+    }
 }

--- a/app/Services/WorkspaceService.php
+++ b/app/Services/WorkspaceService.php
@@ -57,6 +57,22 @@ class WorkspaceService
     }
 
     /**
+     * Get the breadcrumbs (ancestor path) for a workspace.
+     *
+     * @return array<int, array{id: int, name: string}>
+     */
+    public function getBreadcrumbs(int $userId, int $id): array
+    {
+        $workspace = $this->repository->findOrFail($id);
+
+        if ($workspace->owner_id !== $userId) {
+            throw new Exception('Unauthorized to access this workspace.', 403);
+        }
+
+        return $this->repository->getAncestors($workspace);
+    }
+
+    /**
      * Create a new workspace (Root or Child).
      */
     public function createWorkspace(int $userId, array $data): Workspace

--- a/routes/api.php
+++ b/routes/api.php
@@ -23,6 +23,7 @@ Route::middleware('auth:sanctum')->group(function () {
 
     Route::patch('/workspaces/{id}/move', [WorkspaceController::class, 'move']);
     Route::patch('/workspaces/{id}/archive', [WorkspaceController::class, 'archive']);
+    Route::get('/workspaces/{id}/breadcrumbs', [WorkspaceController::class, 'breadcrumbs']);
     Route::post('/workspaces/{workspace}/restore', [WorkspaceController::class, 'restore'])->withTrashed();
 
 });

--- a/tests/Feature/WorkspaceTest.php
+++ b/tests/Feature/WorkspaceTest.php
@@ -765,7 +765,78 @@ test('children hidden from show response after being soft-deleted', function () 
         ->assertJsonCount(0, 'data.children');
 });
 
+describe('Workspace Breadcrumbs (#38)', function () {
+    it('returns breadcrumbs for a root workspace', function () {
+        $root = Workspace::factory()->create(['owner_id' => $this->user->id]);
+
+        $response = $this->actingAs($this->user)->getJson("/api/workspaces/{$root->id}/breadcrumbs");
+
+        $response->assertStatus(200)
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.id', $root->id)
+            ->assertJsonPath('data.0.name', $root->name);
+    });
+
+    it('returns breadcrumbs ordered root to child for a 2-level workspace', function () {
+        $root = Workspace::factory()->create(['owner_id' => $this->user->id]);
+        $child = Workspace::factory()->create([
+            'owner_id' => $this->user->id,
+            'parent_id' => $root->id,
+            'depth' => 2,
+        ]);
+
+        $response = $this->actingAs($this->user)->getJson("/api/workspaces/{$child->id}/breadcrumbs");
+
+        $response->assertStatus(200)
+            ->assertJsonCount(2, 'data')
+            ->assertJsonPath('data.0.id', $root->id)
+            ->assertJsonPath('data.1.id', $child->id);
+    });
+
+    it('returns breadcrumbs ordered root to grandchild for a 3-level workspace', function () {
+        $root = Workspace::factory()->create(['owner_id' => $this->user->id]);
+        $child = Workspace::factory()->create([
+            'owner_id' => $this->user->id,
+            'parent_id' => $root->id,
+            'depth' => 2,
+        ]);
+        $grandchild = Workspace::factory()->create([
+            'owner_id' => $this->user->id,
+            'parent_id' => $child->id,
+            'depth' => 3,
+        ]);
+
+        $response = $this->actingAs($this->user)->getJson("/api/workspaces/{$grandchild->id}/breadcrumbs");
+
+        $response->assertStatus(200)
+            ->assertJsonCount(3, 'data')
+            ->assertJsonPath('data.0.id', $root->id)
+            ->assertJsonPath('data.1.id', $child->id)
+            ->assertJsonPath('data.2.id', $grandchild->id);
+    });
+
+    it('returns 403 when accessing breadcrumbs of another user workspace', function () {
+        $otherUser = User::factory()->create();
+        $workspace = Workspace::factory()->create(['owner_id' => $otherUser->id]);
+
+        $this->actingAs($this->user)
+            ->getJson("/api/workspaces/{$workspace->id}/breadcrumbs")
+            ->assertStatus(403);
+    });
+
+    it('returns only id and name in each breadcrumb item', function () {
+        $root = Workspace::factory()->create(['owner_id' => $this->user->id]);
+
+        $response = $this->actingAs($this->user)->getJson("/api/workspaces/{$root->id}/breadcrumbs");
+
+        $response->assertStatus(200);
+        $item = $response->json('data.0');
+        expect(array_keys($item))->toBe(['id', 'name']);
+    });
+});
+
 describe('Workspace Summary Counter (#39)', function () {
+
     it('includes children_count in the index response', function () {
         $parent = Workspace::factory()->create(['owner_id' => $this->user->id]);
         Workspace::factory()->count(3)->create([


### PR DESCRIPTION
## Summary
Closes #38. Adds a dedicated endpoint to retrieve the full hierarchical path (breadcrumbs) of a workspace from root to the current node.

### New Endpoint
`GET /api/workspaces/{id}/breadcrumbs`

**Response:**
```json
{
  "success": true,
  "message": "Breadcrumbs retrieved successfully",
  "data": [
    { "id": 1, "name": "Root" },
    { "id": 2, "name": "Child" },
    { "id": 3, "name": "Grandchild" }
  ]
}
```

### Changes
- **`WorkspaceRepository`**: Added `getAncestors()` — iteratively traverses parent chain to build ordered ancestor array
- **`WorkspaceService`**: Added `getBreadcrumbs()` — validates ownership, delegates to repository
- **`WorkspaceController`**: Added `breadcrumbs()` — thin controller method, returns ApiResponse
- **`routes/api.php`**: Registered `GET /workspaces/{id}/breadcrumbs` under `auth:sanctum` middleware

### Testing
5 new Pest feature tests:
- Root workspace breadcrumbs (1 item)
- 2-level hierarchy ordering
- 3-level hierarchy ordering
- Unauthorized access returns 403
- Response structure contains only `id` and `name`

66 tests total, all passing.