### PR TITLE
[Feature] Task CRUD API

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Helpers\ApiResponse;
+use App\Http\Requests\StoreTaskRequest;
+use App\Http\Requests\UpdateTaskRequest;
+use App\Services\TaskService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Auth;
+
+class TaskController extends Controller
+{
+    public function __construct(
+        protected TaskService $service
+    ) {}
+
+    /**
+     * Display a listing of tasks for a workspace.
+     */
+    public function index(int $workspaceId): JsonResponse
+    {
+        $tasks = $this->service->getTasksByWorkspace(Auth::id(), $workspaceId);
+
+        return ApiResponse::success($tasks, 'Tasks retrieved successfully');
+    }
+
+    /**
+     * Store a newly created task.
+     */
+    public function store(int $workspaceId, StoreTaskRequest $request): JsonResponse
+    {
+        $task = $this->service->createTask(Auth::id(), $workspaceId, $request->validated());
+
+        return ApiResponse::success($task, 'Task created successfully', 201);
+    }
+
+    /**
+     * Display the specified task.
+     */
+    public function show(int $id): JsonResponse
+    {
+        $task = $this->service->findTask(Auth::id(), $id);
+
+        return ApiResponse::success($task, 'Task retrieved successfully');
+    }
+
+    /**
+     * Update the specified task.
+     */
+    public function update(int $id, UpdateTaskRequest $request): JsonResponse
+    {
+        $task = $this->service->updateTask(Auth::id(), $id, $request->validated());
+
+        return ApiResponse::success($task, 'Task updated successfully');
+    }
+
+    /**
+     * Remove the specified task.
+     */
+    public function destroy(int $id): JsonResponse
+    {
+        $this->service->deleteTask(Auth::id(), $id);
+
+        return ApiResponse::success(null, 'Task deleted successfully');
+    }
+}

--- a/app/Http/Requests/StoreTaskRequest.php
+++ b/app/Http/Requests/StoreTaskRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Enums\TaskPriority;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Enum;
+
+class StoreTaskRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+            'priority' => ['sometimes', new Enum(TaskPriority::class)],
+            'due_date' => ['nullable', 'date', 'after_or_equal:today'],
+            'parent_id' => ['nullable', 'integer', 'exists:tasks,id'],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateTaskRequest.php
+++ b/app/Http/Requests/UpdateTaskRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Enums\TaskPriority;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Enum;
+
+class UpdateTaskRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => ['sometimes', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+            'priority' => ['sometimes', new Enum(TaskPriority::class)],
+            'due_date' => ['nullable', 'date', 'after_or_equal:today'],
+            'parent_id' => ['nullable', 'integer', 'exists:tasks,id'],
+        ];
+    }
+}

--- a/app/Repositories/TaskRepository.php
+++ b/app/Repositories/TaskRepository.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Models\Task;
+use Illuminate\Database\Eloquent\Collection;
+
+class TaskRepository
+{
+    /**
+     * Create a new task.
+     */
+    public function create(array $data): Task
+    {
+        return Task::create($data);
+    }
+
+    /**
+     * Find a task by ID or fail with relations.
+     */
+    public function findOrFail(int $id, array $relations = []): Task
+    {
+        return Task::with($relations)->findOrFail($id);
+    }
+
+    /**
+     * Update an existing task.
+     */
+    public function update(Task $task, array $data): Task
+    {
+        $task->update($data);
+
+        return $task->refresh();
+    }
+
+    /**
+     * Delete a task.
+     */
+    public function delete(Task $task): void
+    {
+        $task->delete();
+    }
+
+    /**
+     * Get tasks by workspace ID with relations.
+     */
+    public function findByWorkspace(int $workspaceId, array $relations = []): Collection
+    {
+        return Task::with($relations)
+            ->where('workspace_id', $workspaceId)
+            ->get();
+    }
+}

--- a/app/Services/TaskService.php
+++ b/app/Services/TaskService.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\TaskStatus;
+use App\Models\Task;
+use App\Repositories\TaskRepository;
+use App\Repositories\WorkspaceRepository;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\DB;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class TaskService
+{
+    public function __construct(
+        protected TaskRepository $taskRepository,
+        protected WorkspaceRepository $workspaceRepository
+    ) {}
+
+    /**
+     * Get all tasks in a workspace with ownership validation.
+     */
+    public function getTasksByWorkspace(int $userId, int $workspaceId): Collection
+    {
+        $workspace = $this->workspaceRepository->findOrFail($workspaceId);
+
+        if ($workspace->owner_id !== $userId) {
+            throw new HttpException(403, 'You do not own this workspace.');
+        }
+
+        return $this->taskRepository->findByWorkspace($workspaceId, ['creator', 'parent', 'children']);
+    }
+
+    /**
+     * Create a task with workspace ownership validation.
+     */
+    public function createTask(int $userId, int $workspaceId, array $data): Task
+    {
+        return DB::transaction(function () use ($userId, $workspaceId, $data) {
+            $workspace = $this->workspaceRepository->findOrFail($workspaceId);
+
+            if ($workspace->owner_id !== $userId) {
+                throw new HttpException(403, 'You do not own this workspace.');
+            }
+
+            $data['workspace_id'] = $workspaceId;
+            $data['creator_id'] = $userId;
+            $data['status'] = TaskStatus::Todo->value;
+
+            return $this->taskRepository->create($data);
+        });
+    }
+
+    /**
+     * find a single task with ownership validation.
+     */
+    public function findTask(int $userId, int $taskId): Task
+    {
+        $task = $this->taskRepository->findOrFail($taskId, ['workspace', 'creator', 'parent', 'children']);
+
+        if ($task->creator_id !== $userId) {
+            throw new HttpException(403, 'You do not own this task.');
+        }
+
+        return $task;
+    }
+
+    /**
+     * Update a task with ownership validation.
+     */
+    public function updateTask(int $userId, int $taskId, array $data): Task
+    {
+        return DB::transaction(function () use ($userId, $taskId, $data) {
+            $task = $this->taskRepository->findOrFail($taskId);
+
+            if ($task->creator_id !== $userId) {
+                throw new HttpException(403, 'You do not own this task.');
+            }
+
+            // Exclude protected fields
+            unset($data['workspace_id'], $data['creator_id'], $data['status']);
+
+            return $this->taskRepository->update($task, $data);
+        });
+    }
+
+    /**
+     * Delete a task with ownership validation.
+     */
+    public function deleteTask(int $userId, int $taskId): void
+    {
+        DB::transaction(function () use ($userId, $taskId) {
+            $task = $this->taskRepository->findOrFail($taskId);
+
+            if ($task->creator_id !== $userId) {
+                throw new HttpException(403, 'You do not own this task.');
+            }
+
+            $this->taskRepository->delete($task);
+        });
+    }
+}

--- a/app/Services/TaskService.php
+++ b/app/Services/TaskService.php
@@ -52,7 +52,7 @@ class TaskService
     }
 
     /**
-     * find a single task with ownership validation.
+     * Find a single task with ownership validation.
      */
     public function findTask(int $userId, int $taskId): Task
     {
@@ -77,7 +77,6 @@ class TaskService
                 throw new HttpException(403, 'You do not own this task.');
             }
 
-            // Exclude protected fields
             unset($data['workspace_id'], $data['creator_id'], $data['status']);
 
             return $this->taskRepository->update($task, $data);

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use App\Helpers\ApiResponse;
 use App\Http\Controllers\Auth\AuthController;
+use App\Http\Controllers\TaskController;
 use App\Http\Controllers\WorkspaceController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
@@ -26,4 +27,11 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('/workspaces/{id}/breadcrumbs', [WorkspaceController::class, 'breadcrumbs']);
     Route::post('/workspaces/{workspace}/restore', [WorkspaceController::class, 'restore'])->withTrashed();
 
+    // Task Routes
+    Route::prefix('workspaces/{workspaceId}')->group(function () {
+        Route::get('/tasks', [TaskController::class, 'index']);
+        Route::post('/tasks', [TaskController::class, 'store']);
+    });
+
+    Route::apiResource('tasks', TaskController::class)->only(['show', 'update', 'destroy']);
 });

--- a/tests/Feature/TaskCrudTest.php
+++ b/tests/Feature/TaskCrudTest.php
@@ -163,3 +163,25 @@ describe('DELETE /api/tasks/{id}', function () {
         $response->assertStatus(403);
     });
 });
+
+describe('404 Not Found edge cases', function () {
+    it('returns 404 when task does not exist', function () {
+        $response = $this->getJson('/api/tasks/99999');
+
+        $response->assertStatus(404);
+    });
+
+    it('returns 404 when workspace does not exist on task creation', function () {
+        $response = $this->postJson('/api/workspaces/99999/tasks', [
+            'title' => 'Task for non-existent workspace',
+        ]);
+
+        $response->assertStatus(404);
+    });
+
+    it('returns 404 when workspace does not exist on task listing', function () {
+        $response = $this->getJson('/api/workspaces/99999/tasks');
+
+        $response->assertStatus(404);
+    });
+});

--- a/tests/Feature/TaskCrudTest.php
+++ b/tests/Feature/TaskCrudTest.php
@@ -1,0 +1,165 @@
+<?php
+
+use App\Enums\TaskStatus;
+use App\Models\Task;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->workspace = Workspace::factory()->create(['owner_id' => $this->user->id]);
+    Sanctum::actingAs($this->user);
+});
+
+describe('POST /api/workspaces/{workspaceId}/tasks', function () {
+    it('can create a task in a workspace', function () {
+        $response = $this->postJson("/api/workspaces/{$this->workspace->id}/tasks", [
+            'title' => 'New Task',
+            'description' => 'Description',
+            'priority' => 'high',
+            'due_date' => now()->addDays(2)->toDateString(),
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('data.title', 'New Task')
+            ->assertJsonPath('data.status', 'todo')
+            ->assertJsonPath('data.priority', 'high');
+
+        $this->assertDatabaseHas('tasks', [
+            'title' => 'New Task',
+            'workspace_id' => $this->workspace->id,
+            'creator_id' => $this->user->id,
+        ]);
+    });
+
+    it('cannot create a task in another user\'s workspace', function () {
+        $otherUser = User::factory()->create();
+        $otherWorkspace = Workspace::factory()->create(['owner_id' => $otherUser->id]);
+
+        $response = $this->postJson("/api/workspaces/{$otherWorkspace->id}/tasks", [
+            'title' => 'Unauthorized Task',
+        ]);
+
+        $response->assertStatus(403);
+    });
+
+    it('validates task creation', function () {
+        $response = $this->postJson("/api/workspaces/{$this->workspace->id}/tasks", [
+            'title' => '',
+            'priority' => 'invalid_priority',
+            'due_date' => now()->subDay()->toDateString(),
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['title', 'priority', 'due_date']);
+    });
+});
+
+describe('GET /api/workspaces/{workspaceId}/tasks', function () {
+    it('can list tasks for a workspace', function () {
+        Task::factory()->count(3)->create([
+            'workspace_id' => $this->workspace->id,
+            'creator_id' => $this->user->id,
+        ]);
+
+        $response = $this->getJson("/api/workspaces/{$this->workspace->id}/tasks");
+
+        $response->assertStatus(200)
+            ->assertJsonPath('success', true)
+            ->assertJsonCount(3, 'data');
+    });
+
+    it('cannot list tasks for another user\'s workspace', function () {
+        $otherUser = User::factory()->create();
+        $otherWorkspace = Workspace::factory()->create(['owner_id' => $otherUser->id]);
+
+        $response = $this->getJson("/api/workspaces/{$otherWorkspace->id}/tasks");
+
+        $response->assertStatus(403);
+    });
+});
+
+describe('GET /api/tasks/{id}', function () {
+    it('can show a task', function () {
+        $task = Task::factory()->create(['creator_id' => $this->user->id]);
+
+        $response = $this->getJson("/api/tasks/{$task->id}");
+
+        $response->assertStatus(200)
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('data.id', $task->id);
+    });
+
+    it('cannot show another user\'s task', function () {
+        $otherUser = User::factory()->create();
+        $otherTask = Task::factory()->create(['creator_id' => $otherUser->id]);
+
+        $response = $this->getJson("/api/tasks/{$otherTask->id}");
+
+        $response->assertStatus(403);
+    });
+});
+
+describe('PUT /api/tasks/{id}', function () {
+    it('can update a task', function () {
+        $task = Task::factory()->create(['creator_id' => $this->user->id]);
+
+        $response = $this->putJson("/api/tasks/{$task->id}", [
+            'title' => 'Updated Task Title',
+            'priority' => 'low',
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.title', 'Updated Task Title')
+            ->assertJsonPath('data.priority', 'low');
+
+        $this->assertDatabaseHas('tasks', [
+            'id' => $task->id,
+            'title' => 'Updated Task Title',
+        ]);
+    });
+
+    it('cannot update protected fields', function () {
+        $otherWorkspace = Workspace::factory()->create(['owner_id' => $this->user->id]);
+        $task = Task::factory()->create([
+            'creator_id' => $this->user->id,
+            'workspace_id' => $this->workspace->id,
+            'status' => TaskStatus::Todo,
+        ]);
+
+        $response = $this->putJson("/api/tasks/{$task->id}", [
+            'workspace_id' => $otherWorkspace->id,
+            'status' => 'done',
+        ]);
+
+        $response->assertStatus(200);
+        $task->refresh();
+        expect($task->workspace_id)->toBe($this->workspace->id);
+        expect($task->status)->toBe(TaskStatus::Todo);
+    });
+});
+
+describe('DELETE /api/tasks/{id}', function () {
+    it('can delete a task', function () {
+        $task = Task::factory()->create(['creator_id' => $this->user->id]);
+
+        $response = $this->deleteJson("/api/tasks/{$task->id}");
+
+        $response->assertStatus(200);
+        $this->assertDatabaseMissing('tasks', ['id' => $task->id]);
+    });
+
+    it('cannot delete another user\'s task', function () {
+        $otherUser = User::factory()->create();
+        $otherTask = Task::factory()->create(['creator_id' => $otherUser->id]);
+
+        $response = $this->deleteJson("/api/tasks/{$otherTask->id}");
+
+        $response->assertStatus(403);
+    });
+});


### PR DESCRIPTION
## Description
Implements the full Task CRUD API following the layered architecture (Controller → Service → Repository). This includes creating, listing, viewing, updating, and deleting tasks with strict ownership validation.

## Changes
- Created `TaskController` with five standardized API endpoints.
- Implemented `TaskService` with business logic and ownership enforcement.
- Created `TaskRepository` for clean data access.
- Implemented `StoreTaskRequest` and `UpdateTaskRequest` for validation.
- Registered nested and direct task routes in `api.php`.
- Added `TaskCrudTest.php` with 11 comprehensive feature tests.

## Verification Results
- 11 Pest tests passed covering all CRUD actions and security boundaries.
- Code style standardized via Pint.

## Linked Issue
Closes #58