### PR TITLE
[Feature] Task Status Management API

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Helpers\ApiResponse;
 use App\Http\Requests\StoreTaskRequest;
 use App\Http\Requests\UpdateTaskRequest;
+use App\Http\Requests\UpdateTaskStatusRequest;
 use App\Services\TaskService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
@@ -63,5 +64,15 @@ class TaskController extends Controller
         $this->service->deleteTask(Auth::id(), $id);
 
         return ApiResponse::success(null, 'Task deleted successfully');
+    }
+
+    /**
+     * Update the status of the specified task.
+     */
+    public function status(int $id, UpdateTaskStatusRequest $request): JsonResponse
+    {
+        $task = $this->service->updateTaskStatus(Auth::id(), $id, $request->validated('status'));
+
+        return ApiResponse::success($task, 'Task status updated successfully');
     }
 }

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -69,9 +69,9 @@ class TaskController extends Controller
     /**
      * Update the status of the specified task.
      */
-    public function status(int $id, UpdateTaskStatusRequest $request): JsonResponse
+    public function status(int $task, UpdateTaskStatusRequest $request): JsonResponse
     {
-        $task = $this->service->updateTaskStatus(Auth::id(), $id, $request->validated('status'));
+        $task = $this->service->updateTaskStatus(Auth::id(), $task, $request->validated('status'));
 
         return ApiResponse::success($task, 'Task status updated successfully');
     }

--- a/app/Http/Requests/UpdateTaskStatusRequest.php
+++ b/app/Http/Requests/UpdateTaskStatusRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Enums\TaskStatus;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Enum;
+
+class UpdateTaskStatusRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     */
+    public function rules(): array
+    {
+        return [
+            'status' => ['required', new Enum(TaskStatus::class)],
+        ];
+    }
+
+    /**
+     * Get the error messages for the defined validation rules.
+     */
+    public function messages(): array
+    {
+        return [
+            'status.required' => 'Status is required.',
+            'status.'.Enum::class => 'Invalid status. Allowed values: todo, in_progress, done.',
+        ];
+    }
+}

--- a/app/Services/TaskService.php
+++ b/app/Services/TaskService.php
@@ -104,12 +104,14 @@ class TaskService
      */
     public function updateTaskStatus(int $userId, int $taskId, string $status): Task
     {
-        $task = $this->taskRepository->findOrFail($taskId);
+        return DB::transaction(function () use ($userId, $taskId, $status) {
+            $task = $this->taskRepository->findOrFail($taskId);
 
-        if ($task->creator_id !== $userId) {
-            throw new HttpException(403, 'You do not own this task.');
-        }
+            if ($task->creator_id !== $userId) {
+                throw new HttpException(403, 'You do not own this task.');
+            }
 
-        return $this->taskRepository->update($task, ['status' => $status]);
+            return $this->taskRepository->update($task, ['status' => $status]);
+        });
     }
 }

--- a/app/Services/TaskService.php
+++ b/app/Services/TaskService.php
@@ -98,4 +98,18 @@ class TaskService
             $this->taskRepository->delete($task);
         });
     }
+
+    /**
+     * Update task status with ownership validation.
+     */
+    public function updateTaskStatus(int $userId, int $taskId, string $status): Task
+    {
+        $task = $this->taskRepository->findOrFail($taskId);
+
+        if ($task->creator_id !== $userId) {
+            throw new HttpException(403, 'You do not own this task.');
+        }
+
+        return $this->taskRepository->update($task, ['status' => $status]);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -34,4 +34,5 @@ Route::middleware('auth:sanctum')->group(function () {
     });
 
     Route::apiResource('tasks', TaskController::class)->only(['show', 'update', 'destroy']);
+    Route::patch('/tasks/{id}/status', [TaskController::class, 'status']);
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -34,5 +34,5 @@ Route::middleware('auth:sanctum')->group(function () {
     });
 
     Route::apiResource('tasks', TaskController::class)->only(['show', 'update', 'destroy']);
-    Route::patch('/tasks/{id}/status', [TaskController::class, 'status']);
+    Route::patch('/tasks/{task}/status', [TaskController::class, 'status']);
 });

--- a/tests/Feature/TaskStatusTest.php
+++ b/tests/Feature/TaskStatusTest.php
@@ -2,7 +2,6 @@
 
 use App\Models\Task;
 use App\Models\User;
-use App\Models\Workspace;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Sanctum\Sanctum;
 
@@ -10,7 +9,6 @@ uses(RefreshDatabase::class);
 
 beforeEach(function () {
     $this->user = User::factory()->create();
-    $this->workspace = Workspace::factory()->create(['owner_id' => $this->user->id]);
     Sanctum::actingAs($this->user);
 });
 
@@ -18,7 +16,6 @@ describe('PATCH /api/tasks/{id}/status', function () {
     it('can update task status to in_progress', function () {
         $task = Task::factory()->create([
             'creator_id' => $this->user->id,
-            'workspace_id' => $this->workspace->id,
             'status' => 'todo',
         ]);
 

--- a/tests/Feature/TaskStatusTest.php
+++ b/tests/Feature/TaskStatusTest.php
@@ -1,0 +1,94 @@
+<?php
+
+use App\Models\Task;
+use App\Models\User;
+use App\Models\Workspace;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+    $this->workspace = Workspace::factory()->create(['owner_id' => $this->user->id]);
+    Sanctum::actingAs($this->user);
+});
+
+describe('PATCH /api/tasks/{id}/status', function () {
+    it('can update task status to in_progress', function () {
+        $task = Task::factory()->create([
+            'creator_id' => $this->user->id,
+            'workspace_id' => $this->workspace->id,
+            'status' => 'todo',
+        ]);
+
+        $response = $this->patchJson("/api/tasks/{$task->id}/status", [
+            'status' => 'in_progress',
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('message', 'Task status updated successfully')
+            ->assertJsonPath('data.status', 'in_progress');
+
+        $this->assertDatabaseHas('tasks', [
+            'id' => $task->id,
+            'status' => 'in_progress',
+        ]);
+    });
+
+    it('can update task status to done', function () {
+        $task = Task::factory()->create([
+            'creator_id' => $this->user->id,
+            'status' => 'in_progress',
+        ]);
+
+        $response = $this->patchJson("/api/tasks/{$task->id}/status", [
+            'status' => 'done',
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.status', 'done');
+    });
+
+    it('cannot update status of another user\'s task', function () {
+        $otherUser = User::factory()->create();
+        $otherTask = Task::factory()->create(['creator_id' => $otherUser->id]);
+
+        $response = $this->patchJson("/api/tasks/{$otherTask->id}/status", [
+            'status' => 'in_progress',
+        ]);
+
+        $response->assertStatus(403);
+    });
+
+    it('validates required status', function () {
+        $task = Task::factory()->create(['creator_id' => $this->user->id]);
+
+        $response = $this->patchJson("/api/tasks/{$task->id}/status", []);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['status'])
+            ->assertJsonFragment(['status' => ['Status is required.']]);
+    });
+
+    it('validates enum status values', function () {
+        $task = Task::factory()->create(['creator_id' => $this->user->id]);
+
+        $response = $this->patchJson("/api/tasks/{$task->id}/status", [
+            'status' => 'invalid_status',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['status'])
+            ->assertJsonFragment(['status' => ['Invalid status. Allowed values: todo, in_progress, done.']]);
+    });
+
+    it('returns 404 for non-existent task', function () {
+        $response = $this->patchJson('/api/tasks/99999/status', [
+            'status' => 'done',
+        ]);
+
+        $response->assertStatus(404);
+    });
+});


### PR DESCRIPTION
## Description
Implement a dedicated API endpoint for managing task status transitions (`PATCH /api/tasks/{id}/status`).

## Changes
- Created `UpdateTaskStatusRequest` with custom enum validation messages.
- Added `status()` method to `TaskController`.
- Added `updateTaskStatus()` method to `TaskService` with ownership validation.
- Registered the `PATCH` route in `api.php`.
- Added `TaskStatusTest.php` with 6 feature tests.

## Verification Results
- 6 Pest tests passed (transitions, ownership, validation, 404).
- Pint formatting applied.

## Linked Issue
Closes #59