### PR TITLE
[Refactor] API Route Standardization and Bug Fixes

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -20,9 +20,9 @@ class TaskController extends Controller
     /**
      * Display a listing of tasks for a workspace.
      */
-    public function index(int $workspaceId): JsonResponse
+    public function index(int $workspace): JsonResponse
     {
-        $tasks = $this->service->getTasksByWorkspace(Auth::id(), $workspaceId);
+        $tasks = $this->service->getTasksByWorkspace(Auth::id(), $workspace);
 
         return ApiResponse::success(TaskResource::collection($tasks), 'Tasks retrieved successfully');
     }
@@ -30,39 +30,39 @@ class TaskController extends Controller
     /**
      * Store a newly created task.
      */
-    public function store(int $workspaceId, StoreTaskRequest $request): JsonResponse
+    public function store(int $workspace, StoreTaskRequest $request): JsonResponse
     {
-        $task = $this->service->createTask(Auth::id(), $workspaceId, $request->validated());
+        $taskModel = $this->service->createTask(Auth::id(), $workspace, $request->validated());
 
-        return ApiResponse::success(new TaskResource($task), 'Task created successfully', 201);
+        return ApiResponse::success(new TaskResource($taskModel), 'Task created successfully', 201);
     }
 
     /**
      * Display the specified task.
      */
-    public function show(int $id): JsonResponse
+    public function show(int $task): JsonResponse
     {
-        $task = $this->service->findTask(Auth::id(), $id);
+        $taskModel = $this->service->findTask(Auth::id(), $task);
 
-        return ApiResponse::success(new TaskResource($task), 'Task retrieved successfully');
+        return ApiResponse::success(new TaskResource($taskModel), 'Task retrieved successfully');
     }
 
     /**
      * Update the specified task.
      */
-    public function update(int $id, UpdateTaskRequest $request): JsonResponse
+    public function update(int $task, UpdateTaskRequest $request): JsonResponse
     {
-        $task = $this->service->updateTask(Auth::id(), $id, $request->validated());
+        $taskModel = $this->service->updateTask(Auth::id(), $task, $request->validated());
 
-        return ApiResponse::success(new TaskResource($task), 'Task updated successfully');
+        return ApiResponse::success(new TaskResource($taskModel), 'Task updated successfully');
     }
 
     /**
      * Remove the specified task.
      */
-    public function destroy(int $id): JsonResponse
+    public function destroy(int $task): JsonResponse
     {
-        $this->service->deleteTask(Auth::id(), $id);
+        $this->service->deleteTask(Auth::id(), $task);
 
         return ApiResponse::success(null, 'Task deleted successfully');
     }

--- a/app/Http/Controllers/WorkspaceController.php
+++ b/app/Http/Controllers/WorkspaceController.php
@@ -81,29 +81,29 @@ class WorkspaceController extends Controller
     /**
      * Update the specified workspace in storage.
      */
-    public function update(int $id, UpdateWorkspaceRequest $request): JsonResponse
+    public function update(int $workspace, UpdateWorkspaceRequest $request): JsonResponse
     {
-        $workspace = $this->service->updateWorkspace(Auth::id(), $id, $request->validated());
+        $workspaceModel = $this->service->updateWorkspace(Auth::id(), $workspace, $request->validated());
 
-        return ApiResponse::success($workspace, 'Workspace updated successfully');
+        return ApiResponse::success($workspaceModel, 'Workspace updated successfully');
     }
 
     /**
      * Display the specified workspace.
      */
-    public function show(int $id): JsonResponse
+    public function show(int $workspace): JsonResponse
     {
-        $workspace = $this->service->findWorkspace(Auth::id(), $id);
+        $workspaceModel = $this->service->findWorkspace(Auth::id(), $workspace);
 
-        return ApiResponse::success($workspace, 'Workspace retrieved successfully');
+        return ApiResponse::success($workspaceModel, 'Workspace retrieved successfully');
     }
 
     /**
      * Remove the specified workspace from storage.
      */
-    public function destroy(int $id): JsonResponse
+    public function destroy(int $workspace): JsonResponse
     {
-        $this->service->deleteWorkspace(Auth::id(), $id);
+        $this->service->deleteWorkspace(Auth::id(), $workspace);
 
         return ApiResponse::success(null, 'Workspace deleted successfully');
     }
@@ -111,15 +111,15 @@ class WorkspaceController extends Controller
     /**
      * Move the specified workspace to a new parent.
      */
-    public function move(MoveWorkspaceRequest $request, int $id): JsonResponse
+    public function move(MoveWorkspaceRequest $request, int $workspace): JsonResponse
     {
-        $workspace = $this->service->moveWorkspace(
+        $workspaceModel = $this->service->moveWorkspace(
             Auth::id(),
-            $id,
+            $workspace,
             $request->validated('parent_id')
         );
 
-        return ApiResponse::success($workspace, 'Workspace moved successfully');
+        return ApiResponse::success($workspaceModel, 'Workspace moved successfully');
     }
 
     /**
@@ -135,20 +135,20 @@ class WorkspaceController extends Controller
     /**
      * Toggle archive status of a workspace.
      */
-    public function archive(int $id): JsonResponse
+    public function archive(int $workspace): JsonResponse
     {
-        $workspace = $this->service->archiveWorkspace(Auth::id(), $id);
-        $status = $workspace->is_archived ? 'archived' : 'unarchived';
+        $workspaceModel = $this->service->archiveWorkspace(Auth::id(), $workspace);
+        $status = $workspaceModel->is_archived ? 'archived' : 'unarchived';
 
-        return ApiResponse::success($workspace, "Workspace {$status} successfully");
+        return ApiResponse::success($workspaceModel, "Workspace {$status} successfully");
     }
 
     /**
      * Get breadcrumbs (ancestor path) for a specific workspace.
      */
-    public function breadcrumbs(int $id): JsonResponse
+    public function breadcrumbs(int $workspace): JsonResponse
     {
-        $breadcrumbs = $this->service->getBreadcrumbs(Auth::id(), $id);
+        $breadcrumbs = $this->service->getBreadcrumbs(Auth::id(), $workspace);
 
         return ApiResponse::success($breadcrumbs, 'Breadcrumbs retrieved successfully');
     }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -42,7 +42,9 @@ return Application::configure(basePath: dirname(__DIR__))
                 }
 
                 $statusCode = 500;
-                if ($e instanceof HttpExceptionInterface) {
+                if ($e instanceof \Illuminate\Auth\AuthenticationException) {
+                    return ApiResponse::error($e->getMessage(), 401);
+                } elseif ($e instanceof HttpExceptionInterface) {
                     $statusCode = $e->getStatusCode();
                 } elseif ($e->getCode() >= 400 && $e->getCode() <= 599) {
                     $statusCode = $e->getCode();

--- a/routes/api.php
+++ b/routes/api.php
@@ -7,30 +7,39 @@ use App\Http\Controllers\WorkspaceController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
-Route::middleware('guest.api')->group(function () {
-    Route::post('/auth/register', [AuthController::class, 'register']);
-    Route::post('/auth/login', [AuthController::class, 'login']);
+Route::middleware('guest.api')->controller(AuthController::class)->prefix('auth')->group(function () {
+    Route::post('/register', 'register');
+    Route::post('/login', 'login');
 });
 
 Route::middleware('auth:sanctum')->group(function () {
+    // User Routes
     Route::get('/user', function (Request $request) {
         return ApiResponse::success($request->user(), 'Authenticated user');
     });
 
-    Route::get('/workspaces/root', [WorkspaceController::class, 'root']);
-    Route::get('/workspaces/trash', [WorkspaceController::class, 'trash']);
-    Route::get('/workspaces/archived', [WorkspaceController::class, 'archived']);
-    Route::apiResource('/workspaces', WorkspaceController::class);
+    // Workspace Custom Routes
+    Route::controller(WorkspaceController::class)->prefix('workspaces')->group(function () {
+        Route::get('/root', 'root');
+        Route::get('/trash', 'trash');
+        Route::get('/archived', 'archived');
+        
+        Route::patch('/{workspace}/move', 'move');
+        Route::patch('/{workspace}/archive', 'archive');
+        Route::get('/{workspace}/breadcrumbs', 'breadcrumbs');
+        Route::post('/{workspace}/restore', 'restore')->withTrashed();
+    });
+    
+    // Workspace Standard Resource
+    Route::apiResource('workspaces', WorkspaceController::class);
 
-    Route::patch('/workspaces/{workspace}/move', [WorkspaceController::class, 'move']);
-    Route::patch('/workspaces/{workspace}/archive', [WorkspaceController::class, 'archive']);
-    Route::get('/workspaces/{workspace}/breadcrumbs', [WorkspaceController::class, 'breadcrumbs']);
-    Route::post('/workspaces/{workspace}/restore', [WorkspaceController::class, 'restore'])->withTrashed();
+    // Task Custom Routes
+    Route::controller(TaskController::class)->prefix('tasks')->group(function () {
+        Route::patch('/{task}/status', 'status');
+    });
 
-    // Task Routes
+    // Task Nested Resource
     Route::apiResource('workspaces.tasks', TaskController::class)
         ->shallow()
         ->only(['index', 'store', 'show', 'update', 'destroy']);
-        
-    Route::patch('/tasks/{task}/status', [TaskController::class, 'status']);
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -22,17 +22,15 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('/workspaces/archived', [WorkspaceController::class, 'archived']);
     Route::apiResource('/workspaces', WorkspaceController::class);
 
-    Route::patch('/workspaces/{id}/move', [WorkspaceController::class, 'move']);
-    Route::patch('/workspaces/{id}/archive', [WorkspaceController::class, 'archive']);
-    Route::get('/workspaces/{id}/breadcrumbs', [WorkspaceController::class, 'breadcrumbs']);
+    Route::patch('/workspaces/{workspace}/move', [WorkspaceController::class, 'move']);
+    Route::patch('/workspaces/{workspace}/archive', [WorkspaceController::class, 'archive']);
+    Route::get('/workspaces/{workspace}/breadcrumbs', [WorkspaceController::class, 'breadcrumbs']);
     Route::post('/workspaces/{workspace}/restore', [WorkspaceController::class, 'restore'])->withTrashed();
 
     // Task Routes
-    Route::prefix('workspaces/{workspaceId}')->group(function () {
-        Route::get('/tasks', [TaskController::class, 'index']);
-        Route::post('/tasks', [TaskController::class, 'store']);
-    });
-
-    Route::apiResource('tasks', TaskController::class)->only(['show', 'update', 'destroy']);
+    Route::apiResource('workspaces.tasks', TaskController::class)
+        ->shallow()
+        ->only(['index', 'store', 'show', 'update', 'destroy']);
+        
     Route::patch('/tasks/{task}/status', [TaskController::class, 'status']);
 });

--- a/tests/Feature/WorkspaceTest.php
+++ b/tests/Feature/WorkspaceTest.php
@@ -976,7 +976,7 @@ describe('Workspace Archiving and Settings (#41)', function () {
         Workspace::factory()->create(['owner_id' => $this->user->id, 'is_archived' => false]);
         Workspace::factory()->create(['owner_id' => $this->user->id, 'is_archived' => true]);
 
-        $response = $this->actingAs($this->user)->getJson('/api/workspaces?include_archived=true');
+        $response = $this->actingAs($this->user)->getJson('/api/workspaces?include_archived=1');
 
         $response->assertStatus(200)
             ->assertJsonCount(2, 'data');

--- a/tests/Unit/Services/WorkspaceServiceTest.php
+++ b/tests/Unit/Services/WorkspaceServiceTest.php
@@ -24,7 +24,6 @@ class WorkspaceServiceTest extends TestCase
 
     public function test_it_calculates_depth_one_for_root_workspaces(): void
     {
-        Auth::shouldReceive('id')->once()->andReturn(1);
 
         $this->repository->expects($this->once())
             ->method('findByNameAndParent')
@@ -38,12 +37,11 @@ class WorkspaceServiceTest extends TestCase
             }))
             ->willReturn(new Workspace);
 
-        $this->service->createWorkspace(['name' => 'Root']);
+        $this->service->createWorkspace(1, ['name' => 'Root']);
     }
 
     public function test_it_calculates_depth_two_for_child_of_root(): void
     {
-        Auth::shouldReceive('id')->andReturn(1);
 
         $parent = new Workspace;
         $parent->id = 10;
@@ -60,12 +58,11 @@ class WorkspaceServiceTest extends TestCase
             }))
             ->willReturn(new Workspace);
 
-        $this->service->createWorkspace(['name' => 'Level 2', 'parent_id' => 10]);
+        $this->service->createWorkspace(1, ['name' => 'Level 2', 'parent_id' => 10]);
     }
 
     public function test_it_throws_exception_when_depth_exceeds_three(): void
     {
-        Auth::shouldReceive('id')->andReturn(1);
 
         $parent = new Workspace;
         $parent->id = 20;
@@ -77,12 +74,11 @@ class WorkspaceServiceTest extends TestCase
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Maximum workspace depth of 3 reached.');
 
-        $this->service->createWorkspace(['name' => 'Level 4', 'parent_id' => 20]);
+        $this->service->createWorkspace(1, ['name' => 'Level 4', 'parent_id' => 20]);
     }
 
     public function test_it_throws_exception_when_parent_belongs_to_another_user(): void
     {
-        Auth::shouldReceive('id')->andReturn(1);
 
         $parent = new Workspace;
         $parent->id = 30;
@@ -94,6 +90,6 @@ class WorkspaceServiceTest extends TestCase
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Parent workspace does not belong to you.');
 
-        $this->service->createWorkspace(['name' => 'Stolen Parent', 'parent_id' => 30]);
+        $this->service->createWorkspace(1, ['name' => 'Stolen Parent', 'parent_id' => 30]);
     }
 }


### PR DESCRIPTION
## Description
This PR standardizes the API routing structure across the application, moving from manual and inconsistent route definitions to strict Laravel conventions. It also fixes 6 pre-existing test failures on the `develop` branch.

## Changes
- Updated `routes/api.php` to use `shallow()` nested resources for `workspaces.tasks`.
- Standardized all route parameters to explicit model bindings (`{workspace}`, `{task}`).
- Updated `WorkspaceController` and `TaskController` method arguments to align with route parameters.
- **Bug Fix**: Handled `AuthenticationException` to return a proper 401 JSON API response rather than a 500 error.
- **Bug Fix**: Fixed `WorkspaceServiceTest` to resolve test failures due to outdated `` signature parameters and unused Auth mocks.
- **Bug Fix**: Updated `WorkspaceTest` to use boolean query `include_archived=1` properly according to Laravel's validation rules.

## Verification
- All 126 Pest tests now passing cleanly on `develop`.