### PR TITLE
refactor: standardize API error handling and response consistency (#68)

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -82,9 +82,9 @@ class TaskController extends Controller
     /**
      * Create a sub-task under a parent task.
      */
-    public function subtask($parentId, StoreSubTaskRequest $request): JsonResponse
+    public function subtask(int $parentId, StoreSubTaskRequest $request): JsonResponse
     {
-        $task = $this->service->createSubTask(Auth::id(), (int) $parentId, $request->validated());
+        $task = $this->service->createSubTask(Auth::id(), $parentId, $request->validated());
 
         return ApiResponse::success(new TaskResource($task), 'Sub-task created successfully', 201);
     }
@@ -92,9 +92,9 @@ class TaskController extends Controller
     /**
      * Move a task to a different parent.
      */
-    public function move($taskId, MoveTaskRequest $request): JsonResponse
+    public function move(int $taskId, MoveTaskRequest $request): JsonResponse
     {
-        $task = $this->service->moveTask(Auth::id(), (int) $taskId, $request->validated('parent_id'));
+        $task = $this->service->moveTask(Auth::id(), $taskId, $request->validated('parent_id'));
 
         return ApiResponse::success(new TaskResource($task), 'Task moved successfully');
     }

--- a/app/Http/Controllers/WorkspaceController.php
+++ b/app/Http/Controllers/WorkspaceController.php
@@ -7,9 +7,9 @@ use App\Http\Requests\MoveWorkspaceRequest;
 use App\Http\Requests\SearchWorkspaceRequest;
 use App\Http\Requests\StoreWorkspaceRequest;
 use App\Http\Requests\UpdateWorkspaceRequest;
-use App\Models\Workspace;
 use App\Services\WorkspaceService;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
 class WorkspaceController extends Controller
@@ -60,9 +60,9 @@ class WorkspaceController extends Controller
     /**
      * Display a listing of root workspaces (parent_id is null).
      */
-    public function root(): JsonResponse
+    public function root(Request $request): JsonResponse
     {
-        $includeArchived = request()->boolean('include_archived');
+        $includeArchived = $request->boolean('include_archived');
         $workspaces = $this->service->getRootWorkspaces(Auth::id(), $includeArchived);
 
         return ApiResponse::success($workspaces, 'Root workspaces retrieved successfully');
@@ -125,9 +125,9 @@ class WorkspaceController extends Controller
     /**
      * Restore a soft-deleted workspace.
      */
-    public function restore(Workspace $workspace): JsonResponse
+    public function restore(int $workspace): JsonResponse
     {
-        $workspace = $this->service->restoreWorkspace(Auth::id(), $workspace->id);
+        $workspace = $this->service->restoreWorkspace(Auth::id(), $workspace);
 
         return ApiResponse::success($workspace, 'Workspace restored successfully');
     }

--- a/app/Services/WorkspaceService.php
+++ b/app/Services/WorkspaceService.php
@@ -4,9 +4,10 @@ namespace App\Services;
 
 use App\Models\Workspace;
 use App\Repositories\WorkspaceRepository;
-use Exception;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Validation\ValidationException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class WorkspaceService
 {
@@ -46,7 +47,7 @@ class WorkspaceService
         $workspace = $this->repository->findOrFail($id);
 
         if ($workspace->owner_id !== $userId) {
-            throw new Exception('Unauthorized to access this workspace.', 403);
+            throw new HttpException(403, 'Unauthorized to access this workspace.');
         }
 
         // Eager load child workspaces and their count
@@ -66,7 +67,7 @@ class WorkspaceService
         $workspace = $this->repository->findOrFail($id);
 
         if ($workspace->owner_id !== $userId) {
-            throw new Exception('Unauthorized to access this workspace.', 403);
+            throw new HttpException(403, 'Unauthorized to access this workspace.');
         }
 
         return $this->repository->getAncestors($workspace);
@@ -84,7 +85,7 @@ class WorkspaceService
             $parent = $this->repository->findOrFail($parentId);
 
             if ($parent->owner_id !== $userId) {
-                throw new Exception('Parent workspace does not belong to you.', 403);
+                throw new HttpException(403, 'Parent workspace does not belong to you.');
             }
 
             $depth = $parent->depth + 1;
@@ -130,7 +131,7 @@ class WorkspaceService
         $workspace = $this->repository->findOrFail($id);
 
         if ($workspace->owner_id !== $userId) {
-            throw new Exception('Unauthorized to update this workspace.', 403);
+            throw new HttpException(403, 'Unauthorized to update this workspace.');
         }
 
         $updateData = [];
@@ -179,7 +180,7 @@ class WorkspaceService
         $workspace = $this->repository->findOrFail($id);
 
         if ($workspace->owner_id !== $userId) {
-            throw new Exception('Unauthorized to archive this workspace.', 403);
+            throw new HttpException(403, 'Unauthorized to archive this workspace.');
         }
 
         $newStatus = ! $workspace->is_archived;
@@ -230,7 +231,7 @@ class WorkspaceService
         $workspace = $this->repository->findOrFail($id);
 
         if ($workspace->owner_id !== $userId) {
-            throw new Exception('Unauthorized to delete this workspace.', 403);
+            throw new HttpException(403, 'Unauthorized to delete this workspace.');
         }
 
         $this->performRecursiveDelete($workspace);
@@ -259,7 +260,7 @@ class WorkspaceService
         $workspace = $this->repository->findOrFail($id);
 
         if ($workspace->owner_id !== $userId) {
-            throw new Exception('Unauthorized to move this workspace.', 403);
+            throw new HttpException(403, 'Unauthorized to move this workspace.');
         }
 
         $newDepth = 1;
@@ -274,7 +275,7 @@ class WorkspaceService
             $parent = $this->repository->findOrFail($parentId);
 
             if ($parent->owner_id !== $userId) {
-                throw new Exception('Parent workspace does not belong to you.', 403);
+                throw new HttpException(403, 'Parent workspace does not belong to you.');
             }
 
             if ($this->repository->isDescendant($id, $parent)) {
@@ -327,11 +328,11 @@ class WorkspaceService
         $workspace = $this->repository->findWithTrashed($id);
 
         if (! $workspace->trashed()) {
-            abort(404, 'Workspace not found in trash.');
+            throw new NotFoundHttpException('Workspace not found in trash.');
         }
 
         if ($workspace->owner_id !== $userId) {
-            abort(403, 'Unauthorized to restore this workspace.');
+            throw new HttpException(403, 'Unauthorized to restore this workspace.');
         }
 
         if ($this->repository->findByNameAndParent($userId, $workspace->parent_id, $workspace->name)) {

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -42,6 +42,10 @@ return Application::configure(basePath: dirname(__DIR__))
                     return ApiResponse::error('Resource not found.', 404);
                 }
 
+                if ($e instanceof TypeError) {
+                    return ApiResponse::error('Resource not found.', 404);
+                }
+
                 $statusCode = 500;
                 if ($e instanceof AuthenticationException) {
                     return ApiResponse::error($e->getMessage(), 401);

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -42,18 +42,17 @@ return Application::configure(basePath: dirname(__DIR__))
                     return ApiResponse::error('Resource not found.', 404);
                 }
 
-                if ($e instanceof TypeError) {
+                if ($e instanceof TypeError && str_contains($e->getMessage(), 'must be of type int, string given')) {
                     return ApiResponse::error('Resource not found.', 404);
                 }
 
-                $statusCode = 500;
                 if ($e instanceof AuthenticationException) {
                     return ApiResponse::error($e->getMessage(), 401);
-                } elseif ($e instanceof HttpExceptionInterface) {
-                    $statusCode = $e->getStatusCode();
-                } elseif ($e->getCode() >= 400 && $e->getCode() <= 599) {
-                    $statusCode = $e->getCode();
                 }
+
+                $statusCode = $e instanceof HttpExceptionInterface
+                    ? $e->getStatusCode()
+                    : 500;
 
                 return ApiResponse::error(
                     $e->getMessage(),

--- a/routes/api.php
+++ b/routes/api.php
@@ -48,7 +48,7 @@ Route::middleware('auth:sanctum')->group(function () {
             Route::patch('/{workspace}/move', 'move');
             Route::patch('/{workspace}/archive', 'archive');
             Route::get('/{workspace}/breadcrumbs', 'breadcrumbs');
-            Route::post('/{workspace}/restore', 'restore')->withTrashed();
+            Route::post('/{workspace}/restore', 'restore');
         });
 
     Route::apiResource('workspaces', WorkspaceController::class);


### PR DESCRIPTION
## Description

An API audit identified 6 inconsistencies in error handling and response format across the 23 API routes. This PR standardizes all exception types and response structures to ensure predictable, frontend-friendly behaviour.

## Acceptance Criteria

- [x] `WorkspaceService` uses `HttpException` (not raw `Exception`) for all 403 authorization guards
- [x] `WorkspaceService::restoreWorkspace` uses `NotFoundHttpException` / `HttpException` instead of `abort()`
- [x] `TaskController::subtask()` and `move()` have proper `int` type hints — removes silent `(int)` cast bug
- [x] `WorkspaceController::restore()` accepts `int $workspace` (consistent with all other methods)
- [x] `WorkspaceController::root()` injects `Request` instead of using `request()` global helper
- [x] `bootstrap/app.php` maps `TypeError` (non-integer route param) to `404` instead of `500`
- [x] `routes/api.php` removes `->withTrashed()` (no longer needed after restore binding change)
- [x] All 138 tests pass

## Technical Notes

- No business logic was changed — only exception types, type hints, and request injection
- The `TypeError` → 404 mapping in the global handler ensures a string like `/api/tasks/abc/move` returns `{ success: false, message: "Resource not found.", errors: null }` with HTTP 404
- Pint formatting applied on all modified files
