### PR TITLE
feat: implement user logout api with sanctum (#70)

### DIFF
--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -8,6 +8,7 @@ use App\Http\Requests\Auth\LoginRequest;
 use App\Http\Requests\Auth\StoreRegisterRequest;
 use App\Services\AuthService;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 
 class AuthController extends Controller
 {
@@ -38,5 +39,15 @@ class AuthController extends Controller
         $request->session()->regenerate();
 
         return ApiResponse::success(null, 'Login successful');
+    }
+
+    /**
+     * Handle the user logout request.
+     */
+    public function logout(Request $request): JsonResponse
+    {
+        $this->authService->logout($request);
+
+        return ApiResponse::success(null, 'Logout successful');
     }
 }

--- a/app/Services/AuthService.php
+++ b/app/Services/AuthService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Models\User;
 use App\Repositories\UserRepository;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\ValidationException;
 
@@ -40,5 +41,16 @@ class AuthService
         Auth::login($user);
 
         return $user;
+    }
+
+    /**
+     * Log out the authenticated user.
+     */
+    public function logout(Request $request): void
+    {
+        Auth::guard('web')->logout();
+
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -26,7 +26,11 @@ Route::middleware('guest.api')
 |--------------------------------------------------------------------------
 */
 Route::middleware('auth:sanctum')->group(function () {
-    Route::post('/auth/logout', [AuthController::class, 'logout']);
+    Route::controller(AuthController::class)
+        ->prefix('auth')
+        ->group(function () {
+            Route::post('/logout', 'logout');
+        });
 
     Route::get('/user', function (Request $request) {
         return ApiResponse::success($request->user(), 'Authenticated user');

--- a/routes/api.php
+++ b/routes/api.php
@@ -26,6 +26,7 @@ Route::middleware('guest.api')
 |--------------------------------------------------------------------------
 */
 Route::middleware('auth:sanctum')->group(function () {
+    Route::post('/auth/logout', [AuthController::class, 'logout']);
 
     Route::get('/user', function (Request $request) {
         return ApiResponse::success($request->user(), 'Authenticated user');

--- a/tests/Feature/Auth/LogoutTest.php
+++ b/tests/Feature/Auth/LogoutTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+use function Pest\Laravel\assertGuest;
+use function Pest\Laravel\postJson;
+
+uses(RefreshDatabase::class);
+
+it('allows an authenticated user to log out', function () {
+    $user = User::factory()->create();
+
+    postJson('/api/auth/logout')
+        ->assertUnauthorized(); // Ensure it requires authentication
+
+    $response = $this->withHeader('Referer', 'http://localhost')->actingAs($user)->postJson('/api/auth/logout');
+
+    $response->assertOk()
+        ->assertJson([
+            'success' => true,
+            'message' => 'Logout successful',
+            'data' => null,
+        ]);
+
+    assertGuest('web');
+});
+
+it('prevents a guest from logging out', function () {
+    postJson('/api/auth/logout')
+        ->assertUnauthorized()
+        ->assertJson([
+            'success' => false,
+            'message' => 'Unauthenticated.',
+        ]);
+});

--- a/tests/Feature/Auth/LogoutTest.php
+++ b/tests/Feature/Auth/LogoutTest.php
@@ -3,18 +3,14 @@
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
-use function Pest\Laravel\assertGuest;
-use function Pest\Laravel\postJson;
-
 uses(RefreshDatabase::class);
 
 it('allows an authenticated user to log out', function () {
     $user = User::factory()->create();
 
-    postJson('/api/auth/logout')
-        ->assertUnauthorized(); // Ensure it requires authentication
-
-    $response = $this->withHeader('Referer', 'http://localhost')->actingAs($user)->postJson('/api/auth/logout');
+    $response = $this->withHeader('Referer', 'http://localhost')
+        ->actingAs($user)
+        ->postJson('/api/auth/logout');
 
     $response->assertOk()
         ->assertJson([
@@ -22,12 +18,20 @@ it('allows an authenticated user to log out', function () {
             'message' => 'Logout successful',
             'data' => null,
         ]);
+});
 
-    assertGuest('web');
+it('destroys the session on logout', function () {
+    $user = User::factory()->create();
+
+    $this->withHeader('Referer', 'http://localhost')
+        ->actingAs($user)
+        ->postJson('/api/auth/logout');
+
+    $this->assertGuest('web');
 });
 
 it('prevents a guest from logging out', function () {
-    postJson('/api/auth/logout')
+    $this->postJson('/api/auth/logout')
         ->assertUnauthorized()
         ->assertJson([
             'success' => false,


### PR DESCRIPTION
## Description

This PR implements the Logout API endpoint utilizing Laravel Sanctum SPA authentication mode. It strictly follows the `sanctum-auth` skill guidelines to ensure a secure session termination.

Closes #70

## Changes Made

1. **Service Layer (`AuthService.php`)**
   - Added `logout()` method.
   - Triggers `Auth::guard('web')->logout()`.
   - Invalidates the current session and regenerates the CSRF token to prevent session fixation attacks.

2. **Controller Layer (`AuthController.php`)**
   - Added the `logout()` endpoint.
   - Follows the application's standard API response format by returning `ApiResponse::success()`.

3. **Routing (`routes/api.php`)**
   - Added `POST /api/auth/logout`.
   - Placed strictly under the `auth:sanctum` middleware group to guarantee that only authenticated users can access the route.

4. **Testing (`LogoutTest.php`)**
   - Added Pest tests to verify successful logout behaviors, explicitly simulating SPA requests using the `Referer` header.
   - Added test assertions to ensure guest users receive a `401 Unauthorized` response when attempting to hit the logout endpoint.

## Verification

- All 140 tests pass successfully.
- Code formatted correctly with Laravel Pint.
